### PR TITLE
[codex] Refine setup wizard Git prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ then run the wizard inside that checkout:
 make setup
 ```
 
-In this flow, keep the existing Git repository when prompted; the wizard will
-clean up the template files and can create the initial commit without changing
-your `origin`.
+In this flow, the wizard detects your repository from `origin`, preserves Git
+history, and only asks whether to commit the generated setup changes.
 
 If you clone the original template directly instead, use:
 

--- a/docs/en/getting-started/quick-start.md
+++ b/docs/en/getting-started/quick-start.md
@@ -17,9 +17,9 @@ clone that new repository, and run:
 make setup
 ```
 
-When the wizard asks about Git, keep the existing repository and let it create
-the initial commit. Your `origin` already points at your repository in this
-flow.
+The wizard detects your repository from `origin`, preserves Git history, and
+only asks whether to commit the generated setup changes. Your `origin` already
+points at your repository in this flow.
 
 If you cloned the original template directly instead, run:
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -24,8 +24,8 @@ then run the wizard inside that checkout:
 make setup
 ```
 
-Keep the existing Git repository when prompted. The wizard will clean up the
-template files and can create the initial commit without changing your `origin`.
+The wizard detects your repository from `origin`, preserves Git history, and
+only asks whether to commit the generated setup changes.
 
 If you clone the original template directly instead, use:
 

--- a/docs/en/reference/makefile.md
+++ b/docs/en/reference/makefile.md
@@ -120,8 +120,8 @@ uv run --group setup python -m management.setup_wizard $(ARGS)
 - Configures local filesystem, local MinIO, or remote S3-compatible storage
 - Rewrites the README for the generated app
 - Sets optional public origins, repository metadata, ports, and Logfire defaults
-- Can preserve an existing Git repository or reinitialize Git for direct template clones
-- Can set `origin` from the repository URL when Git is reinitialized and create the initial commit
+- Infers repository metadata from GitHub template checkouts and preserves their `origin`
+- Can reinitialize Git for direct template clones, set `origin` from the repository URL, and create a generated setup commit
 - Can remove template docs and setup-only files
 
 ### `make update-dependencies`

--- a/management/setup_wizard/prompts.py
+++ b/management/setup_wizard/prompts.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
+from urllib.parse import urlsplit
 
 import questionary
 
@@ -17,13 +18,8 @@ DISTRIBUTION_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*[a-z0-9]$")
 TEMPLATE_PROJECT_NAME = "fastdjango"
 TEMPLATE_PACKAGE_NAME = "fastdjango"
 TEMPLATE_DISTRIBUTION_NAME = "fastdjango"
-TEMPLATE_REPOSITORY_URLS = frozenset(
-    {
-        "git@github.com:maksimzayats/fastdjango",
-        "https://github.com/maksimzayats/fastdjango",
-        "ssh://git@github.com/maksimzayats/fastdjango",
-    },
-)
+TEMPLATE_REPOSITORY_URL = "https://github.com/maksimzayats/fastdjango"
+GITHUB_REPOSITORY_PATH_PARTS = 2
 MAX_PORT = 65535
 
 
@@ -67,8 +63,17 @@ class LogfirePromptAnswers:
 
 @dataclass(frozen=True, kw_only=True)
 class GitPromptAnswers:
+    repo_url: str | None = None
     reinitialize_git_repository: bool = True
     create_initial_commit: bool = True
+
+
+@dataclass(frozen=True, kw_only=True)
+class GitCheckoutDetection:
+    inferred_repo_url: str | None = None
+    prompt_for_repo_url: bool = True
+    prompt_for_reinitialize_git_repository: bool = True
+    default_reinitialize_git_repository: bool = True
 
 
 def prompt_for_answers(*, repo_root: Path) -> SetupAnswers:
@@ -90,7 +95,6 @@ def prompt_for_answers(*, repo_root: Path) -> SetupAnswers:
     )
     keep_docs = _ask_confirm("Keep documentation?", default=True)
     docs_site_url = _ask_docs_site_url(keep_docs=keep_docs)
-    repo_url = _ask_repo_url()
     git_answers = _ask_git_answers(repo_root=repo_root)
     storage_mode = _ask_storage_mode()
     storage_answers = _ask_storage_answers(storage_mode=storage_mode)
@@ -114,7 +118,7 @@ def prompt_for_answers(*, repo_root: Path) -> SetupAnswers:
         keep_docs=keep_docs,
         delete_wizard=delete_wizard,
         overwrite_env=overwrite_env,
-        repo_url=repo_url,
+        repo_url=git_answers.repo_url,
         reinitialize_git_repository=git_answers.reinitialize_git_repository,
         create_initial_commit=git_answers.create_initial_commit,
         s3_endpoint_url=storage_answers.s3_endpoint_url,
@@ -269,30 +273,91 @@ def _ask_repo_url() -> str | None:
 
 
 def _ask_git_answers(*, repo_root: Path | None = None) -> GitPromptAnswers:
-    reinitialize_git_repository = _ask_confirm(
-        "Reinitialize Git repository to remove cloned-template history and old origin?",
-        default=_default_reinitialize_git_repository(repo_root=repo_root),
-    )
+    git_checkout_detection = _detect_git_checkout(repo_root=repo_root)
+    if git_checkout_detection.prompt_for_repo_url:
+        repo_url = _ask_repo_url()
+    else:
+        repo_url = git_checkout_detection.inferred_repo_url
+
+    if git_checkout_detection.prompt_for_reinitialize_git_repository:
+        reinitialize_git_repository = _ask_confirm(
+            "Reinitialize Git repository to remove cloned-template history and old origin?",
+            default=git_checkout_detection.default_reinitialize_git_repository,
+        )
+    else:
+        reinitialize_git_repository = False
 
     return GitPromptAnswers(
+        repo_url=repo_url,
         reinitialize_git_repository=reinitialize_git_repository,
-        create_initial_commit=_ask_confirm("Create initial commit?", default=True),
+        create_initial_commit=_ask_confirm("Create generated project setup commit?", default=True),
     )
 
 
 def _default_reinitialize_git_repository(*, repo_root: Path | None) -> bool:
+    return _detect_git_checkout(repo_root=repo_root).default_reinitialize_git_repository
+
+
+def _detect_git_checkout(*, repo_root: Path | None) -> GitCheckoutDetection:
     if repo_root is None:
-        return True
+        return GitCheckoutDetection()
 
     if not (repo_root / ".git").exists():
-        return True
+        return GitCheckoutDetection()
 
     origin_url = _current_origin_url(repo_root=repo_root)
     if origin_url is None:
-        return False
+        return GitCheckoutDetection(default_reinitialize_git_repository=False)
 
-    normalized_origin_url = origin_url.casefold().removesuffix(".git").rstrip("/")
-    return normalized_origin_url in TEMPLATE_REPOSITORY_URLS
+    browser_safe_origin_url = _github_browser_url_from_origin(origin_url=origin_url)
+    if browser_safe_origin_url is None:
+        return GitCheckoutDetection(default_reinitialize_git_repository=False)
+
+    if browser_safe_origin_url.casefold() == TEMPLATE_REPOSITORY_URL:
+        return GitCheckoutDetection(default_reinitialize_git_repository=True)
+
+    return GitCheckoutDetection(
+        inferred_repo_url=browser_safe_origin_url,
+        prompt_for_repo_url=False,
+        prompt_for_reinitialize_git_repository=False,
+        default_reinitialize_git_repository=False,
+    )
+
+
+def _github_browser_url_from_origin(*, origin_url: str) -> str | None:
+    origin_url = origin_url.strip()
+    if not origin_url:
+        return None
+
+    scp_match = re.fullmatch(
+        pattern=r"git@github\.com:(?P<path>[^?#\s]+)",
+        string=origin_url,
+        flags=re.IGNORECASE,
+    )
+    if scp_match is not None:
+        return _github_browser_url_from_path(path=scp_match.group("path"))
+
+    parsed_origin_url = urlsplit(origin_url)
+    if parsed_origin_url.scheme not in {"http", "https", "ssh"}:
+        return None
+
+    if (parsed_origin_url.hostname or "").casefold() != "github.com":
+        return None
+
+    return _github_browser_url_from_path(path=parsed_origin_url.path)
+
+
+def _github_browser_url_from_path(*, path: str) -> str | None:
+    normalized_path = path.strip().lstrip("/").rstrip("/").removesuffix(".git")
+    owner_and_repo = normalized_path.split("/")
+    if len(owner_and_repo) != GITHUB_REPOSITORY_PATH_PARTS:
+        return None
+
+    owner, repo = owner_and_repo
+    if not owner or not repo:
+        return None
+
+    return f"https://github.com/{owner}/{repo}"
 
 
 def _current_origin_url(*, repo_root: Path) -> str | None:

--- a/management/setup_wizard/prompts.py
+++ b/management/setup_wizard/prompts.py
@@ -313,7 +313,9 @@ def _detect_git_checkout(*, repo_root: Path | None) -> GitCheckoutDetection:
     if browser_safe_origin_url is None:
         return GitCheckoutDetection(default_reinitialize_git_repository=False)
 
-    if browser_safe_origin_url.casefold() == TEMPLATE_REPOSITORY_URL:
+    if _normalized_repository_url(browser_safe_origin_url) == _normalized_repository_url(
+        TEMPLATE_REPOSITORY_URL,
+    ):
         return GitCheckoutDetection(default_reinitialize_git_repository=True)
 
     return GitCheckoutDetection(
@@ -348,7 +350,10 @@ def _github_browser_url_from_origin(*, origin_url: str) -> str | None:
 
 
 def _github_browser_url_from_path(*, path: str) -> str | None:
-    normalized_path = path.strip().lstrip("/").rstrip("/").removesuffix(".git")
+    normalized_path = path.strip().lstrip("/").rstrip("/")
+    if normalized_path.casefold().endswith(".git"):
+        normalized_path = normalized_path[: -len(".git")]
+
     owner_and_repo = normalized_path.split("/")
     if len(owner_and_repo) != GITHUB_REPOSITORY_PATH_PARTS:
         return None
@@ -358,6 +363,10 @@ def _github_browser_url_from_path(*, path: str) -> str | None:
         return None
 
     return f"https://github.com/{owner}/{repo}"
+
+
+def _normalized_repository_url(value: str) -> str:
+    return value.strip().rstrip("/").casefold().removesuffix(".git")
 
 
 def _current_origin_url(*, repo_root: Path) -> str | None:

--- a/tests/setup_wizard/test_prompts.py
+++ b/tests/setup_wizard/test_prompts.py
@@ -176,6 +176,8 @@ def test_git_prompts_default_to_reinitialize_and_initial_commit(
     values = iter((True, True))
     calls: list[tuple[str, bool]] = []
 
+    monkeypatch.setattr(prompts, "_ask_repo_url", lambda: "https://github.com/acme/acme-api")
+
     def fake_ask_confirm(message: str, *, default: bool) -> bool:
         calls.append((message, default))
         return next(values)
@@ -184,11 +186,12 @@ def test_git_prompts_default_to_reinitialize_and_initial_commit(
 
     answers = _ask_git_answers()
 
+    assert answers.repo_url == "https://github.com/acme/acme-api"
     assert answers.reinitialize_git_repository is True
     assert answers.create_initial_commit is True
     assert calls == [
         ("Reinitialize Git repository to remove cloned-template history and old origin?", True),
-        ("Create initial commit?", True),
+        ("Create generated project setup commit?", True),
     ]
 
 
@@ -198,6 +201,8 @@ def test_git_prompts_can_preserve_git_and_create_initial_commit(
     values = iter((False, True))
     calls: list[tuple[str, bool]] = []
 
+    monkeypatch.setattr(prompts, "_ask_repo_url", lambda: None)
+
     def fake_ask_confirm(message: str, *, default: bool) -> bool:
         calls.append((message, default))
         return next(values)
@@ -206,26 +211,72 @@ def test_git_prompts_can_preserve_git_and_create_initial_commit(
 
     answers = _ask_git_answers()
 
+    assert answers.repo_url is None
     assert answers.reinitialize_git_repository is False
     assert answers.create_initial_commit is True
     assert calls == [
         ("Reinitialize Git repository to remove cloned-template history and old origin?", True),
-        ("Create initial commit?", True),
+        ("Create generated project setup commit?", True),
     ]
 
 
-def test_git_reinitialize_default_is_false_for_user_owned_origin(
+def test_user_owned_http_origin_skips_repo_url_and_reinitialize_prompts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     (tmp_path / ".git").mkdir()
+    calls: list[tuple[str, bool]] = []
     monkeypatch.setattr(
         prompts,
         "_current_origin_url",
-        _fake_origin_url("https://github.com/acme/acme-api"),
+        _fake_origin_url("https://github.com/acme/acme-api.git"),
     )
 
+    def fail_ask_repo_url() -> str | None:
+        pytest.fail("Repository URL should be inferred from a user-owned GitHub origin.")
+
+    def fake_ask_confirm(message: str, *, default: bool) -> bool:
+        calls.append((message, default))
+        return True
+
+    monkeypatch.setattr(prompts, "_ask_repo_url", fail_ask_repo_url)
+    monkeypatch.setattr(prompts, "_ask_confirm", fake_ask_confirm)
+
+    answers = _ask_git_answers(repo_root=tmp_path)
+
+    assert answers.repo_url == "https://github.com/acme/acme-api"
+    assert answers.reinitialize_git_repository is False
+    assert answers.create_initial_commit is True
+    assert calls == [("Create generated project setup commit?", True)]
     assert _default_reinitialize_git_repository(repo_root=tmp_path) is False
+
+
+@pytest.mark.parametrize(
+    "origin_url",
+    [
+        "git@github.com:acme/acme-api.git",
+        "ssh://git@github.com/acme/acme-api.git",
+    ],
+)
+def test_user_owned_ssh_origin_is_inferred_as_https_repo_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    origin_url: str,
+) -> None:
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(prompts, "_current_origin_url", _fake_origin_url(origin_url))
+    monkeypatch.setattr(
+        prompts,
+        "_ask_repo_url",
+        lambda: pytest.fail("Repository URL should be inferred from GitHub SSH origin."),
+    )
+    monkeypatch.setattr(prompts, "_ask_confirm", lambda *_args, **_kwargs: False)
+
+    answers = _ask_git_answers(repo_root=tmp_path)
+
+    assert answers.repo_url == "https://github.com/acme/acme-api"
+    assert answers.reinitialize_git_repository is False
+    assert answers.create_initial_commit is False
 
 
 def test_git_reinitialize_default_is_true_for_template_origin(
@@ -233,23 +284,91 @@ def test_git_reinitialize_default_is_true_for_template_origin(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     (tmp_path / ".git").mkdir()
+    calls: list[tuple[str, bool]] = []
     monkeypatch.setattr(
         prompts,
         "_current_origin_url",
         _fake_origin_url("git@github.com:MaksimZayats/fastdjango.git"),
     )
 
+    def fake_ask_confirm(message: str, *, default: bool) -> bool:
+        calls.append((message, default))
+        return True
+
+    monkeypatch.setattr(prompts, "_ask_repo_url", lambda: "https://github.com/acme/acme-api")
+    monkeypatch.setattr(prompts, "_ask_confirm", fake_ask_confirm)
+
+    answers = _ask_git_answers(repo_root=tmp_path)
+
+    assert answers.repo_url == "https://github.com/acme/acme-api"
+    assert answers.reinitialize_git_repository is True
+    assert answers.create_initial_commit is True
+    assert calls == [
+        ("Reinitialize Git repository to remove cloned-template history and old origin?", True),
+        ("Create generated project setup commit?", True),
+    ]
     assert _default_reinitialize_git_repository(repo_root=tmp_path) is True
 
 
-def test_git_reinitialize_default_is_false_when_origin_is_unknown(
+def test_existing_repo_with_no_origin_keeps_explicit_prompt_path(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     (tmp_path / ".git").mkdir()
+    calls: list[tuple[str, bool]] = []
     monkeypatch.setattr(prompts, "_current_origin_url", _fake_origin_url(None))
 
+    def fake_ask_confirm(message: str, *, default: bool) -> bool:
+        calls.append((message, default))
+        return default
+
+    monkeypatch.setattr(prompts, "_ask_repo_url", lambda: "https://github.com/acme/acme-api")
+    monkeypatch.setattr(prompts, "_ask_confirm", fake_ask_confirm)
+
+    answers = _ask_git_answers(repo_root=tmp_path)
+
+    assert answers.repo_url == "https://github.com/acme/acme-api"
+    assert answers.reinitialize_git_repository is False
+    assert answers.create_initial_commit is True
+    assert calls == [
+        ("Reinitialize Git repository to remove cloned-template history and old origin?", False),
+        ("Create generated project setup commit?", True),
+    ]
     assert _default_reinitialize_git_repository(repo_root=tmp_path) is False
+
+
+@pytest.mark.parametrize(
+    "origin_url",
+    [
+        "file:///tmp/acme-api.git",
+        "../acme-api.git",
+    ],
+)
+def test_unsupported_local_origins_do_not_get_forced_into_docs_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    origin_url: str,
+) -> None:
+    (tmp_path / ".git").mkdir()
+    calls: list[tuple[str, bool]] = []
+    monkeypatch.setattr(prompts, "_current_origin_url", _fake_origin_url(origin_url))
+
+    def fake_ask_confirm(message: str, *, default: bool) -> bool:
+        calls.append((message, default))
+        return default
+
+    monkeypatch.setattr(prompts, "_ask_repo_url", lambda: None)
+    monkeypatch.setattr(prompts, "_ask_confirm", fake_ask_confirm)
+
+    answers = _ask_git_answers(repo_root=tmp_path)
+
+    assert answers.repo_url is None
+    assert answers.reinitialize_git_repository is False
+    assert answers.create_initial_commit is True
+    assert calls == [
+        ("Reinitialize Git repository to remove cloned-template history and old origin?", False),
+        ("Create generated project setup commit?", True),
+    ]
 
 
 def test_git_reinitialize_default_is_true_without_existing_git_repo(tmp_path: Path) -> None:

--- a/tests/setup_wizard/test_prompts.py
+++ b/tests/setup_wizard/test_prompts.py
@@ -310,6 +310,25 @@ def test_git_reinitialize_default_is_true_for_template_origin(
     assert _default_reinitialize_git_repository(repo_root=tmp_path) is True
 
 
+def test_template_origin_detection_normalizes_git_suffix_case(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(
+        prompts,
+        "_current_origin_url",
+        _fake_origin_url("https://github.com/MaksimZayats/fastdjango.GIT/"),
+    )
+    monkeypatch.setattr(prompts, "_ask_repo_url", lambda: "https://github.com/acme/acme-api")
+    monkeypatch.setattr(prompts, "_ask_confirm", lambda *_args, **kwargs: kwargs["default"])
+
+    answers = _ask_git_answers(repo_root=tmp_path)
+
+    assert answers.reinitialize_git_repository is True
+    assert _default_reinitialize_git_repository(repo_root=tmp_path) is True
+
+
 def test_existing_repo_with_no_origin_keeps_explicit_prompt_path(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- Detect GitHub template checkouts from the local `origin` remote.
- Infer browser-safe repository URLs for user-owned GitHub template repos and skip the repo URL/reinitialize prompts.
- Preserve direct `fastdjango` clone behavior, including the default Git reinitialization path.
- Update README/docs wording for the recommended GitHub template flow.

## Validation

- `uv run pytest tests/setup_wizard/ --no-cov`
- `make lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified setup wizard behavior: the wizard automatically detects your existing repository, preserves Git history, and simplifies Git interactions to a single confirmation prompt for the generated setup changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->