### PR TITLE
refactor: keep setup output spacing tidy

### DIFF
--- a/management/setup_wizard/planner.py
+++ b/management/setup_wizard/planner.py
@@ -279,6 +279,7 @@ def _rewrite_makefile(
         else _remove_setup_target(content)
     )
     content = _remove_docs_targets(content) if not answers.keep_docs else content
+    content = _normalize_makefile_spacing(content)
     plan.add_write(path, content=content, detail="Update Makefile")
 
 
@@ -394,6 +395,10 @@ def _remove_docs_targets(content: str) -> str:
     )
     content = re.sub(pattern=r"\ndocs-build:\n\t.*\n", repl="\n", string=content)
     return content.replace(" docs docs-build", "")
+
+
+def _normalize_makefile_spacing(content: str) -> str:
+    return re.sub(pattern=r"\n{3,}", repl="\n\n", string=content).rstrip() + "\n"
 
 
 def _is_python_package(path: Path) -> bool:

--- a/tests/setup_wizard/test_planner.py
+++ b/tests/setup_wizard/test_planner.py
@@ -279,6 +279,40 @@ def test_self_delete_removes_wizard_files_and_setup_dependency_group(tmp_path: P
     assert "setup:" not in (tmp_path / "Makefile").read_text()
 
 
+def test_generated_setup_files_keep_tidy_blank_lines(tmp_path: Path) -> None:
+    setup_cases = {
+        "remove_docs": _answers(keep_docs=False, delete_wizard=False),
+        "remove_wizard": _answers(delete_wizard=True),
+        "remove_local_services_docs_and_wizard": _answers(
+            database_mode=DatabaseMode.SQLITE,
+            redis_mode=RedisMode.REMOTE_REDIS,
+            redis_url="redis://default:secret@redis.example.com:6379/0",
+            storage_mode=StorageMode.LOCAL,
+            keep_docs=False,
+            delete_wizard=True,
+        ),
+    }
+
+    for case_name, answers in setup_cases.items():
+        repo_root = tmp_path / case_name
+        _create_mini_repo(repo_root=repo_root)
+
+        build_setup_plan(repo_root=repo_root, answers=answers).apply(run_commands=False)
+
+        for relative_path in (
+            "Makefile",
+            "docker/docker-compose.yaml",
+            "docker/docker-compose.local.yaml",
+            "docker/docker-compose.test.yaml",
+        ):
+            content = (repo_root / relative_path).read_text(encoding="utf-8")
+            assert content.endswith("\n"), f"{case_name}: {relative_path} lacks final newline"
+            assert not content.endswith("\n\n"), (
+                f"{case_name}: {relative_path} has trailing blank line"
+            )
+            assert "\n\n\n" not in content, f"{case_name}: {relative_path} has repeated blank lines"
+
+
 def _answers(
     *,
     project_name: str = "Example API",


### PR DESCRIPTION
## Summary
- Keeps generated setup artifacts tidy when optional sections are omitted.
- Adds coverage for final newlines and repeated blank lines across setup outputs.

## Validation
- `make lint`
- `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated setup files (Makefiles and docker-compose configurations) now maintain proper formatting with normalized blank-line spacing.
  * Excessive consecutive blank lines are automatically cleaned up and files are guaranteed to end with a single trailing newline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->