### PR TITLE
[setup] add authentication choices

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ LOGGING_LEVEL=DEBUG
 
 # Secrets
 DJANGO_SECRET_KEY=example-django-secret-key
+
+# Authentication
+AUTHENTICATION_MODE=jwt-refresh-session
 JWT_SECRET_KEY=example-jwt-secret-key-with-at-least-32-bytes
 
 # HTTP

--- a/.env.test.example
+++ b/.env.test.example
@@ -5,6 +5,9 @@ LOGGING_LEVEL=DEBUG
 
 # Secrets
 DJANGO_SECRET_KEY=test-django-secret-key
+
+# Authentication
+AUTHENTICATION_MODE=jwt-refresh-session
 JWT_SECRET_KEY=test-jwt-secret-key-with-at-least-32-bytes
 
 # Observability

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ not keep the template history or `origin`.
 
 The wizard renames the checkout folder to the project slug, renames the project
 and Python package, writes env files, configures database, Redis, storage, docs,
-public origins, observability, and Git setup for the flow you chose.
+authentication, public origins, observability, and Git setup for the flow you
+chose.
 
 ## Run Locally
 

--- a/docs/en/getting-started/quick-start.md
+++ b/docs/en/getting-started/quick-start.md
@@ -32,8 +32,8 @@ does not keep the template history or `origin`.
 
 The setup wizard renames the checkout folder to the project slug, renames the
 project and Python package, writes `.env`, rewrites the app README, and lets you
-choose database, Redis, storage, docs, public origins, Logfire defaults, and Git
-setup for the flow you chose.
+choose database, Redis, storage, authentication, docs, public origins, Logfire
+defaults, and Git setup for the flow you chose.
 
 ## Step 2: Install dependencies
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -35,8 +35,8 @@ git clone https://github.com/maksimzayats/fastdjango.git && cd fastdjango && mak
 
 The wizard renames the checkout folder to the project slug, renames the project
 and Python package, writes `.env`, configures database, Redis, storage, docs,
-public origins, Logfire defaults, and Git setup for the flow you chose, then
-prints the next commands.
+authentication, public origins, Logfire defaults, and Git setup for the flow you
+chose, then prints the next commands.
 
 ## Key features
 

--- a/docs/en/reference/environment-variables.md
+++ b/docs/en/reference/environment-variables.md
@@ -69,19 +69,33 @@ ALLOWED_HOSTS=["localhost","127.0.0.1","example.com"]
 CSRF_TRUSTED_ORIGINS=["https://example.com"]
 ```
 
+## Authentication Settings
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `AUTHENTICATION_MODE` | No | `jwt-refresh-session` | `jwt-refresh-session` for built-in JWT access tokens and refresh sessions, `static-api-keys` for `X-API-Key` authentication from JSON, or `custom` to skip built-in protected routes while you add your own auth |
+| `STATIC_API_KEYS` | Yes* | `{}` | JSON object mapping API keys to static principals. Required when `AUTHENTICATION_MODE=static-api-keys` |
+
+Static API key example:
+```bash
+AUTHENTICATION_MODE=static-api-keys
+STATIC_API_KEYS={"local-dev-key":{"id":1,"username":"local-api-key","email":"local-api-key@example.com","first_name":"Local","last_name":"API Key","is_staff":true,"is_superuser":false}}
+```
+
 ## JWT Settings
 
 Prefix: `JWT_`
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `JWT_SECRET_KEY` | Yes | - | Secret key for signing tokens |
+| `JWT_SECRET_KEY` | Yes* | - | Secret key for signing tokens. Required when `AUTHENTICATION_MODE=jwt-refresh-session` |
 | `JWT_ALGORITHM` | No | `HS256` | JWT signing algorithm |
 | `JWT_TYP` | No | `at+jwt` | JWT `typ` claim for access tokens |
 | `JWT_ACCESS_TOKEN_EXPIRE_MINUTES` | No | `15` | Access token expiration in minutes |
 
 Example:
 ```bash
+AUTHENTICATION_MODE=jwt-refresh-session
 JWT_SECRET_KEY=your-super-secret-jwt-key-with-at-least-32-bytes
 JWT_ALGORITHM=HS256
 JWT_ACCESS_TOKEN_EXPIRE_MINUTES=60
@@ -251,6 +265,9 @@ LOGGING_LEVEL=DEBUG
 
 # Secrets
 DJANGO_SECRET_KEY=example-django-secret-key
+
+# Authentication
+AUTHENTICATION_MODE=jwt-refresh-session
 JWT_SECRET_KEY=example-jwt-secret-key-with-at-least-32-bytes
 
 # HTTP

--- a/docs/en/reference/makefile.md
+++ b/docs/en/reference/makefile.md
@@ -118,6 +118,7 @@ uv run --group setup python -m management.setup_wizard $(ARGS)
 - Configures SQLite, local Docker PostgreSQL, or remote PostgreSQL
 - Configures local Docker Redis or remote Redis
 - Configures local filesystem, local MinIO, or remote S3-compatible storage
+- Configures built-in JWT refresh-session auth, static API keys, or a custom auth placeholder
 - Rewrites the README for the generated app
 - Sets optional public origins, repository metadata, ports, and Logfire defaults
 - Infers repository metadata from GitHub template checkouts and preserves their `origin`

--- a/management/setup_wizard/env.py
+++ b/management/setup_wizard/env.py
@@ -5,13 +5,20 @@ from dataclasses import dataclass
 from json import dumps
 from urllib.parse import urlsplit
 
-from management.setup_wizard.models import DatabaseMode, RedisMode, SetupAnswers, StorageMode
+from management.setup_wizard.models import (
+    AuthenticationMode,
+    DatabaseMode,
+    RedisMode,
+    SetupAnswers,
+    StorageMode,
+)
 
 
 @dataclass(frozen=True, kw_only=True)
 class EnvCredentials:
     django_key: str
     jwt_key: str
+    static_api_key: str
     postgres_key: str
     redis_key: str
 
@@ -22,6 +29,7 @@ def build_env_content(*, answers: SetupAnswers) -> str:
         credentials=EnvCredentials(
             django_key=secrets.token_urlsafe(48),
             jwt_key=secrets.token_urlsafe(48),
+            static_api_key=secrets.token_urlsafe(32),
             postgres_key=secrets.token_urlsafe(32),
             redis_key=secrets.token_urlsafe(32),
         ),
@@ -37,6 +45,7 @@ def build_env_example_content(*, answers: SetupAnswers) -> str:
         credentials=EnvCredentials(
             django_key="example-django-key",
             jwt_key="example-jwt-key-with-at-least-32-bytes",
+            static_api_key="example-static-api-key",
             postgres_key="example-postgres-key",
             redis_key="example-redis-key",
         ),
@@ -46,7 +55,16 @@ def build_env_example_content(*, answers: SetupAnswers) -> str:
     return _join_env_lines(lines=lines)
 
 
-def build_test_env_example_content() -> str:
+def build_test_env_example_content(
+    *,
+    answers: SetupAnswers | None = None,
+) -> str:
+    authentication_mode = (
+        answers.authentication_mode
+        if answers is not None
+        else AuthenticationMode.JWT_REFRESH_SESSION
+    )
+
     return _join_env_lines(
         lines=[
             "# Application",
@@ -56,7 +74,13 @@ def build_test_env_example_content() -> str:
             "",
             "# Secrets",
             "DJANGO_SECRET_KEY=test-django-secret-key",
-            "JWT_SECRET_KEY=test-jwt-secret-key-with-at-least-32-bytes",
+            "",
+            "# Authentication",
+            *_build_authentication_lines(
+                authentication_mode=authentication_mode,
+                jwt_key="test-jwt-secret-key-with-at-least-32-bytes",
+                static_api_key="test-static-api-key",
+            ),
             "",
             "# Observability",
             "LOGFIRE_ENABLED=false",
@@ -92,7 +116,15 @@ def _build_base_env_lines(
         "",
         "# Secrets",
         f"DJANGO_SECRET_KEY={credentials.django_key}",
-        f"JWT_SECRET_KEY={credentials.jwt_key}",
+        "",
+        "# Authentication",
+        *(
+            _build_authentication_lines(
+                authentication_mode=answers.authentication_mode,
+                jwt_key=credentials.jwt_key,
+                static_api_key=credentials.static_api_key,
+            )
+        ),
         "",
         "# HTTP",
         *(_build_http_lines(answers=answers)),
@@ -130,6 +162,42 @@ def _build_base_env_lines(
         ],
     )
     return lines
+
+
+def _build_authentication_lines(
+    *,
+    authentication_mode: AuthenticationMode,
+    jwt_key: str,
+    static_api_key: str,
+) -> list[str]:
+    lines = [f"AUTHENTICATION_MODE={authentication_mode.value}"]
+    if authentication_mode == AuthenticationMode.JWT_REFRESH_SESSION:
+        lines.append(f"JWT_SECRET_KEY={jwt_key}")
+        return lines
+
+    if authentication_mode == AuthenticationMode.STATIC_API_KEYS:
+        lines.append(
+            f"STATIC_API_KEYS={_static_api_keys_env_value(api_key=static_api_key)}",
+        )
+
+    return lines
+
+
+def _static_api_keys_env_value(*, api_key: str) -> str:
+    return dumps(
+        {
+            api_key: {
+                "id": 1,
+                "username": "local-api-key",
+                "email": "local-api-key@example.com",
+                "first_name": "Local",
+                "last_name": "API Key",
+                "is_staff": True,
+                "is_superuser": False,
+            },
+        },
+        separators=(",", ":"),
+    )
 
 
 def _build_http_lines(*, answers: SetupAnswers) -> list[str]:

--- a/management/setup_wizard/file_operations.py
+++ b/management/setup_wizard/file_operations.py
@@ -27,8 +27,9 @@ class FilePlan:
             ),
         )
 
-    def add_delete(self, path: Path, *, detail: str) -> None:
-        if not path.exists():
+    def add_delete(self, path: Path, *, detail: str, exists_path: Path | None = None) -> None:
+        check_path = exists_path or path
+        if not check_path.exists():
             return
 
         self.operations.append(

--- a/management/setup_wizard/models.py
+++ b/management/setup_wizard/models.py
@@ -23,6 +23,12 @@ class RedisMode(StrEnum):
     REMOTE_REDIS = "remote-redis"
 
 
+class AuthenticationMode(StrEnum):
+    JWT_REFRESH_SESSION = "jwt-refresh-session"
+    STATIC_API_KEYS = "static-api-keys"
+    CUSTOM = "custom"
+
+
 @dataclass(frozen=True, kw_only=True)
 class SetupAnswers:
     project_name: str
@@ -36,6 +42,7 @@ class SetupAnswers:
     delete_wizard: bool
     overwrite_env: bool
 
+    authentication_mode: AuthenticationMode = AuthenticationMode.JWT_REFRESH_SESSION
     repo_url: str | None = None
     reinitialize_git_repository: bool = True
     create_initial_commit: bool = True

--- a/management/setup_wizard/planner.py
+++ b/management/setup_wizard/planner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import textwrap
 import tomllib
 from collections.abc import Callable
 from pathlib import Path
@@ -19,7 +20,7 @@ from management.setup_wizard.env import (
     build_test_env_example_content,
 )
 from management.setup_wizard.file_operations import FilePlan
-from management.setup_wizard.models import SetupAnswers
+from management.setup_wizard.models import AuthenticationMode, SetupAnswers
 from management.setup_wizard.python_rewrite import rewrite_python_imports
 from management.setup_wizard.readme import build_project_readme
 from management.setup_wizard.text_rewrite import (
@@ -55,6 +56,11 @@ def build_setup_plan(
         current_package_name=resolved_package_name,
     )
     _plan_python_rewrites(
+        plan=plan,
+        answers=answers,
+        current_package_name=resolved_package_name,
+    )
+    _plan_authentication_mode(
         plan=plan,
         answers=answers,
         current_package_name=resolved_package_name,
@@ -141,6 +147,1131 @@ def _plan_python_rewrites(
         )
 
 
+def _plan_authentication_mode(
+    *,
+    plan: FilePlan,
+    answers: SetupAnswers,
+    current_package_name: str,
+) -> None:
+    if answers.authentication_mode == AuthenticationMode.JWT_REFRESH_SESSION:
+        return
+
+    _plan_remove_refresh_session_auth(
+        plan=plan,
+        answers=answers,
+        current_package_name=current_package_name,
+    )
+
+    if answers.authentication_mode == AuthenticationMode.STATIC_API_KEYS:
+        _plan_static_api_key_auth(plan=plan, answers=answers)
+        return
+
+    _plan_custom_auth(
+        plan=plan,
+        answers=answers,
+        current_package_name=current_package_name,
+    )
+
+
+def _plan_remove_refresh_session_auth(
+    *,
+    plan: FilePlan,
+    answers: SetupAnswers,
+    current_package_name: str,
+) -> None:
+    package_path = _package_path(plan=plan, answers=answers)
+    auth_path = package_path / "core" / "authentication"
+
+    plan.add_write(
+        package_path / "infrastructure" / "django" / "settings.py",
+        content=_django_settings_without_authentication_app(
+            plan=plan,
+            answers=answers,
+            current_package_name=current_package_name,
+        ),
+        detail="Remove refresh-session authentication Django app",
+    )
+    plan.add_write(
+        package_path / "core" / "user" / "models.py",
+        content=_user_model_without_refresh_sessions(),
+        detail="Remove refresh-session reverse relation annotation",
+    )
+
+    source_auth_path = plan.repo_root / "src" / current_package_name / "core" / "authentication"
+    for relative_path in (
+        "apps.py",
+        "dtos.py",
+        "exceptions.py",
+        "models.py",
+        "use_cases.py",
+        "delivery/django",
+        "delivery/fastapi/controllers.py",
+        "delivery/fastapi/schemas.py",
+        "delivery/fastapi/throttling.py",
+        "migrations",
+        "services",
+    ):
+        plan.add_delete(
+            auth_path / relative_path,
+            detail="Remove refresh-session authentication code",
+            exists_path=source_auth_path / relative_path,
+        )
+
+    for relative_path in (
+        "tests/integration/core/authentication/delivery/fastapi/test_controllers.py",
+        "tests/unit/core/authentication/services",
+        "tests/unit/core/authentication/test_use_cases.py",
+    ):
+        plan.add_delete(
+            plan.repo_root / relative_path,
+            detail="Remove refresh-session authentication tests",
+        )
+
+
+def _plan_static_api_key_auth(*, plan: FilePlan, answers: SetupAnswers) -> None:
+    package_name = answers.package_name
+    package_path = _package_path(plan=plan, answers=answers)
+
+    plan.add_write(
+        package_path / "core" / "authentication" / "delivery" / "fastapi" / "auth.py",
+        content=_static_api_key_auth_module(package_name=package_name),
+        detail="Keep only static API key authentication",
+    )
+    plan.add_write(
+        package_path / "entrypoints" / "fastapi" / "factories.py",
+        content=_fastapi_factory_without_token_routes(package_name=package_name),
+        detail="Remove refresh-session token routes",
+    )
+    plan.add_write(
+        package_path / "core" / "user" / "delivery" / "fastapi" / "controllers.py",
+        content=_static_api_key_user_controller(package_name=package_name),
+        detail="Use static API key auth for protected user routes",
+    )
+    plan.add_write(
+        plan.repo_root / "tests" / "integration" / "conftest.py",
+        content=_static_api_key_integration_conftest(package_name=package_name),
+        detail="Use static API keys in integration tests",
+    )
+    plan.add_write(
+        plan.repo_root / "tests" / "integration" / "factories.py",
+        content=_test_factories_without_jwt(package_name=package_name),
+        detail="Remove JWT test client helper",
+    )
+    plan.add_write(
+        plan.repo_root
+        / "tests"
+        / "integration"
+        / "core"
+        / "authentication"
+        / "delivery"
+        / "fastapi"
+        / "test_auth.py",
+        content=_static_api_key_integration_auth_test(package_name=package_name),
+        detail="Test static API key authentication",
+    )
+    plan.add_write(
+        plan.repo_root
+        / "tests"
+        / "unit"
+        / "core"
+        / "authentication"
+        / "delivery"
+        / "fastapi"
+        / "test_auth.py",
+        content=_static_api_key_unit_auth_test(package_name=package_name),
+        detail="Test static API key auth dependency",
+    )
+    plan.add_write(
+        plan.repo_root
+        / "tests"
+        / "integration"
+        / "core"
+        / "user"
+        / "delivery"
+        / "fastapi"
+        / "test_controllers.py",
+        content=_static_api_key_user_controller_test(package_name=package_name),
+        detail="Use static API key auth in user controller tests",
+    )
+
+
+def _plan_custom_auth(
+    *,
+    plan: FilePlan,
+    answers: SetupAnswers,
+    current_package_name: str,
+) -> None:
+    package_name = answers.package_name
+    package_path = _package_path(plan=plan, answers=answers)
+
+    plan.add_delete(
+        package_path / "core" / "authentication",
+        detail="Remove built-in authentication code",
+        exists_path=plan.repo_root / "src" / current_package_name / "core" / "authentication",
+    )
+    plan.add_delete(
+        plan.repo_root / "tests" / "integration" / "core" / "authentication",
+        detail="Remove built-in authentication tests",
+    )
+    plan.add_delete(
+        plan.repo_root / "tests" / "unit" / "core" / "authentication",
+        detail="Remove built-in authentication tests",
+    )
+    plan.add_write(
+        package_path / "entrypoints" / "fastapi" / "factories.py",
+        content=_fastapi_factory_without_token_routes(package_name=package_name),
+        detail="Remove built-in authentication routes",
+    )
+    plan.add_write(
+        package_path / "core" / "user" / "delivery" / "fastapi" / "controllers.py",
+        content=_custom_auth_user_controller(package_name=package_name),
+        detail="Remove built-in protected user routes",
+    )
+    plan.add_write(
+        plan.repo_root / "tests" / "integration" / "conftest.py",
+        content=_custom_auth_integration_conftest(package_name=package_name),
+        detail="Remove built-in auth test environment setup",
+    )
+    plan.add_write(
+        plan.repo_root / "tests" / "integration" / "factories.py",
+        content=_test_factories_without_jwt(package_name=package_name),
+        detail="Remove JWT test client helper",
+    )
+    plan.add_write(
+        plan.repo_root
+        / "tests"
+        / "integration"
+        / "core"
+        / "user"
+        / "delivery"
+        / "fastapi"
+        / "test_controllers.py",
+        content=_custom_auth_user_controller_test(package_name=package_name),
+        detail="Keep only public user controller tests",
+    )
+
+
+def _package_path(*, plan: FilePlan, answers: SetupAnswers) -> Path:
+    return plan.repo_root / "src" / answers.package_name
+
+
+def _django_settings_without_authentication_app(
+    *,
+    plan: FilePlan,
+    answers: SetupAnswers,
+    current_package_name: str,
+) -> str:
+    source_path = (
+        plan.repo_root / "src" / current_package_name / "infrastructure" / "django" / "settings.py"
+    )
+    content = source_path.read_text(encoding="utf-8")
+    content = rewrite_python_imports(
+        source=content,
+        old_package_name=current_package_name,
+        new_package_name=answers.package_name,
+    )
+    content = _replace_text_references(
+        text=content,
+        answers=answers,
+        current_package_name=current_package_name,
+    )
+    authentication_app = f'"{answers.package_name}.core.authentication.apps.AuthenticationConfig",'
+    lines = [line for line in content.splitlines() if authentication_app not in line]
+
+    return "\n".join(lines) + ("\n" if content.endswith("\n") else "")
+
+
+def _user_model_without_refresh_sessions() -> str:
+    return _dedent(
+        """
+        from django.contrib.auth.models import AbstractUser
+        from django.db import models
+
+
+        class User(AbstractUser):
+            email = models.EmailField(verbose_name="email address", unique=True)
+
+            def __str__(self) -> str:
+                return f"User(id={self.pk}, username={self.username})"
+        """,
+    )
+
+
+def _static_api_key_auth_module(*, package_name: str) -> str:
+    return _dedent(
+        f"""
+        import secrets
+        from dataclasses import dataclass
+        from http import HTTPStatus
+
+        from diwire import Injected
+        from fastapi import HTTPException
+        from fastapi.requests import Request
+        from fastapi.security import APIKeyHeader
+        from pydantic import BaseModel, ConfigDict, EmailStr, Field
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+        from starlette.datastructures import State
+
+        from {package_name}.foundation.factories import BaseFactory
+
+
+        class StaticAPIKeyPrincipal(BaseModel):
+            model_config = ConfigDict(frozen=True)
+
+            id: int
+            username: str
+            email: EmailStr
+            first_name: str = ""
+            last_name: str = ""
+            is_staff: bool = False
+            is_superuser: bool = False
+
+            @property
+            def pk(self) -> int:
+                return self.id
+
+
+        class StaticAPIKeyRegistrySettings(BaseSettings):
+            model_config = SettingsConfigDict(populate_by_name=True)
+
+            api_keys: dict[str, StaticAPIKeyPrincipal] = Field(
+                default_factory=dict,
+                validation_alias="STATIC_API_KEYS",
+            )
+
+            def get_principal_for_api_key(
+                self,
+                *,
+                api_key: str,
+            ) -> StaticAPIKeyPrincipal | None:
+                for registered_api_key, principal in self.api_keys.items():
+                    if secrets.compare_digest(api_key, registered_api_key):
+                        return principal
+
+                return None
+
+
+        class AuthenticatedRequestState(State):
+            user: StaticAPIKeyPrincipal
+
+
+        class AuthenticatedRequest(Request):
+            state: AuthenticatedRequestState
+
+
+        @dataclass(kw_only=True)
+        class StaticAPIKeyAuthFactory(BaseFactory):
+            _settings: Injected[StaticAPIKeyRegistrySettings]
+
+            def __call__(
+                self,
+                *,
+                require_staff: bool = False,
+                require_superuser: bool = False,
+            ) -> StaticAPIKeyAuth:
+                return StaticAPIKeyAuth(
+                    settings=self._settings,
+                    require_staff=require_staff,
+                    require_superuser=require_superuser,
+                )
+
+
+        class StaticAPIKeyAuth(APIKeyHeader):
+            def __init__(
+                self,
+                settings: StaticAPIKeyRegistrySettings,
+                *,
+                require_staff: bool = False,
+                require_superuser: bool = False,
+            ) -> None:
+                super().__init__(name="X-API-Key", auto_error=False)
+                self._settings = settings
+                self._require_staff = require_staff
+                self._require_superuser = require_superuser
+
+            async def __call__(self, request: Request) -> str | None:
+                api_key = await super().__call__(request)
+                if api_key is None:
+                    raise HTTPException(
+                        status_code=HTTPStatus.UNAUTHORIZED,
+                        detail="API key is required",
+                    )
+
+                principal = self._settings.get_principal_for_api_key(api_key=api_key)
+                if principal is None:
+                    raise HTTPException(
+                        status_code=HTTPStatus.UNAUTHORIZED,
+                        detail="Invalid API key",
+                    )
+
+                self._check_permissions(principal=principal)
+                request.state.user = principal
+
+                return api_key
+
+            def _check_permissions(self, *, principal: StaticAPIKeyPrincipal) -> None:
+                if self._require_staff and not principal.is_staff:
+                    raise HTTPException(
+                        status_code=HTTPStatus.FORBIDDEN,
+                        detail="Staff access required",
+                    )
+
+                if self._require_superuser and not principal.is_superuser:
+                    raise HTTPException(
+                        status_code=HTTPStatus.FORBIDDEN,
+                        detail="Superuser access required",
+                    )
+        """,
+    )
+
+
+def _fastapi_factory_without_token_routes(*, package_name: str) -> str:
+    return _dedent(
+        f"""
+        from collections.abc import AsyncIterator
+        from contextlib import asynccontextmanager
+        from dataclasses import dataclass
+        from typing import cast
+
+        from a2wsgi import WSGIMiddleware
+        from a2wsgi.wsgi_typing import WSGIApp
+        from diwire import Injected
+        from fastapi import APIRouter, FastAPI
+        from pydantic import Field
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+        from starlette.middleware.cors import CORSMiddleware
+        from starlette.middleware.trustedhost import TrustedHostMiddleware
+        from starlette.types import ASGIApp
+
+        from {package_name}.core.health.delivery.fastapi.controllers import HealthController
+        from {package_name}.core.user.delivery.fastapi.controllers import UserController
+        from {package_name}.entrypoints.django.factories import DjangoWSGIFactory
+        from {package_name}.foundation.factories import BaseFactory
+        from {package_name}.infrastructure.anyio.configurator import AnyIOConfigurator
+        from {package_name}.infrastructure.django.middleware import (
+            DjangoDatabaseConnectionMiddleware,
+        )
+        from {package_name}.infrastructure.logfire.instrumentor import OpenTelemetryInstrumentor
+        from {package_name}.infrastructure.shared import ApplicationSettings, Environment
+
+
+        class FastAPISettings(BaseSettings):
+            allowed_hosts: list[str] = Field(default_factory=lambda: ["localhost", "127.0.0.1"])
+
+
+        class CORSSettings(BaseSettings):
+            model_config = SettingsConfigDict(env_prefix="CORS_")
+
+            allow_credentials: bool = True
+            allow_origins: list[str] = Field(default_factory=lambda: ["http://localhost"])
+            allow_methods: list[str] = Field(default_factory=lambda: ["*"])
+            allow_headers: list[str] = Field(default_factory=lambda: ["*"])
+
+
+        @dataclass(kw_only=True)
+        class Lifespan:
+            _anyio_configurator: Injected[AnyIOConfigurator]
+
+            @asynccontextmanager
+            async def __call__(self, _app: FastAPI) -> AsyncIterator[None]:
+                self._anyio_configurator.configure()
+
+                yield
+
+
+        @dataclass(kw_only=True)
+        class FastAPIFactory(BaseFactory):
+            _application_settings: Injected[ApplicationSettings]
+            _fastapi_settings: Injected[FastAPISettings]
+            _cors_settings: Injected[CORSSettings]
+
+            _lifespan: Injected[Lifespan]
+            _telemetry_instrumentor: Injected[OpenTelemetryInstrumentor]
+            _django_wsgi_factory: Injected[DjangoWSGIFactory]
+
+            _health_controller: Injected[HealthController]
+            _user_controller: Injected[UserController]
+
+            def __call__(
+                self,
+                *,
+                include_django: bool = True,
+                add_trusted_hosts_middleware: bool = True,
+                add_cors_middleware: bool = True,
+            ) -> FastAPI:
+                docs_url = (
+                    "/docs"
+                    if self._application_settings.environment != Environment.PRODUCTION
+                    else None
+                )
+
+                app = FastAPI(
+                    title="API",
+                    lifespan=self._lifespan,
+                    docs_url=docs_url,
+                    redoc_url=None,
+                )
+
+                self._telemetry_instrumentor.instrument_fastapi(app=app)
+                self._add_middlewares(
+                    app=app,
+                    add_trusted_hosts_middleware=add_trusted_hosts_middleware,
+                    add_cors_middleware=add_cors_middleware,
+                )
+                self._register_controllers(app=app)
+
+                if include_django:
+                    django_wsgi = cast(WSGIApp, self._django_wsgi_factory())
+                    django_asgi = cast(ASGIApp, WSGIMiddleware(django_wsgi))
+                    app.mount("/django", django_asgi)
+
+                return app
+
+            def _add_middlewares(
+                self,
+                app: FastAPI,
+                *,
+                add_trusted_hosts_middleware: bool = True,
+                add_cors_middleware: bool = True,
+            ) -> None:
+                app.add_middleware(DjangoDatabaseConnectionMiddleware)
+
+                if add_trusted_hosts_middleware:
+                    app.add_middleware(
+                        TrustedHostMiddleware,
+                        allowed_hosts=self._fastapi_settings.allowed_hosts,
+                    )
+
+                if add_cors_middleware:
+                    app.add_middleware(
+                        CORSMiddleware,
+                        allow_origins=self._cors_settings.allow_origins,
+                        allow_credentials=self._cors_settings.allow_credentials,
+                        allow_methods=self._cors_settings.allow_methods,
+                        allow_headers=self._cors_settings.allow_headers,
+                    )
+
+            def _register_controllers(
+                self,
+                app: FastAPI,
+            ) -> None:
+                health_router = APIRouter(tags=["health"])
+                self._health_controller.register(health_router)
+                app.include_router(health_router)
+
+                user_router = APIRouter(tags=["user"])
+                self._user_controller.register(user_router)
+                app.include_router(user_router)
+        """,
+    )
+
+
+def _static_api_key_user_controller(*, package_name: str) -> str:
+    return _dedent(
+        f"""
+        from dataclasses import dataclass
+        from http import HTTPStatus
+        from typing import Any
+
+        from diwire import Injected
+        from fastapi import APIRouter, Depends, HTTPException
+
+        from {package_name}.core.authentication.delivery.fastapi.auth import (
+            AuthenticatedRequest,
+            StaticAPIKeyAuthFactory,
+        )
+        from {package_name}.core.user.delivery.fastapi.schemas import (
+            CreateUserRequestSchema,
+            UserSchema,
+        )
+        from {package_name}.core.user.use_cases import UserUseCase
+        from {package_name}.foundation.delivery.controllers import BaseAsyncController
+
+
+        @dataclass(kw_only=True)
+        class UserController(BaseAsyncController):
+            _static_api_key_auth_factory: Injected[StaticAPIKeyAuthFactory]
+            _user_use_case: Injected[UserUseCase]
+
+            def __post_init__(self) -> None:
+                self._auth = self._static_api_key_auth_factory()
+                self._staff_auth = self._static_api_key_auth_factory(require_staff=True)
+                super().__post_init__()
+
+            def register(self, registry: APIRouter) -> None:
+                registry.add_api_route(
+                    path="/v1/users/",
+                    endpoint=self.create_user,
+                    methods=["POST"],
+                    response_model=UserSchema,
+                )
+
+                registry.add_api_route(
+                    path="/v1/users/me",
+                    endpoint=self.get_current_user,
+                    methods=["GET"],
+                    dependencies=[Depends(self._auth)],
+                    response_model=UserSchema,
+                )
+
+                registry.add_api_route(
+                    path="/v1/users/{{user_id}}",
+                    endpoint=self.get_user_by_id,
+                    methods=["GET"],
+                    dependencies=[Depends(self._staff_auth)],
+                    response_model=UserSchema,
+                )
+
+            async def create_user(self, request_body: CreateUserRequestSchema) -> UserSchema:
+                user = await self._user_use_case.create_user(data=request_body)
+
+                return UserSchema.model_validate(user, from_attributes=True)
+
+            async def get_current_user(self, request: AuthenticatedRequest) -> UserSchema:
+                return UserSchema.model_validate(request.state.user, from_attributes=True)
+
+            async def get_user_by_id(
+                self,
+                user_id: int,
+            ) -> UserSchema:
+                user = await self._user_use_case.get_user_by_id(user_id=user_id)
+                if user is None:
+                    raise HTTPException(
+                        status_code=HTTPStatus.NOT_FOUND,
+                        detail="User not found",
+                    )
+
+                return UserSchema.model_validate(user, from_attributes=True)
+
+            async def handle_exception(self, exception: Exception) -> Any:
+                if isinstance(exception, UserUseCase.WEAK_PASSWORD_ERROR):
+                    raise HTTPException(
+                        status_code=HTTPStatus.BAD_REQUEST,
+                        detail="Password does not meet the strength requirements",
+                    ) from exception
+
+                if isinstance(exception, UserUseCase.USER_ALREADY_EXISTS_ERROR):
+                    raise HTTPException(
+                        status_code=HTTPStatus.CONFLICT,
+                        detail="A user with the given username or email already exists",
+                    ) from exception
+
+                return await super().handle_exception(exception)
+        """,
+    )
+
+
+def _custom_auth_user_controller(*, package_name: str) -> str:
+    return _dedent(
+        f"""
+        from dataclasses import dataclass
+        from http import HTTPStatus
+        from typing import Any
+
+        from diwire import Injected
+        from fastapi import APIRouter, HTTPException
+
+        from {package_name}.core.user.delivery.fastapi.schemas import (
+            CreateUserRequestSchema,
+            UserSchema,
+        )
+        from {package_name}.core.user.use_cases import UserUseCase
+        from {package_name}.foundation.delivery.controllers import BaseAsyncController
+
+
+        @dataclass(kw_only=True)
+        class UserController(BaseAsyncController):
+            _user_use_case: Injected[UserUseCase]
+
+            def register(self, registry: APIRouter) -> None:
+                registry.add_api_route(
+                    path="/v1/users/",
+                    endpoint=self.create_user,
+                    methods=["POST"],
+                    response_model=UserSchema,
+                )
+
+            async def create_user(self, request_body: CreateUserRequestSchema) -> UserSchema:
+                user = await self._user_use_case.create_user(data=request_body)
+
+                return UserSchema.model_validate(user, from_attributes=True)
+
+            async def handle_exception(self, exception: Exception) -> Any:
+                if isinstance(exception, UserUseCase.WEAK_PASSWORD_ERROR):
+                    raise HTTPException(
+                        status_code=HTTPStatus.BAD_REQUEST,
+                        detail="Password does not meet the strength requirements",
+                    ) from exception
+
+                if isinstance(exception, UserUseCase.USER_ALREADY_EXISTS_ERROR):
+                    raise HTTPException(
+                        status_code=HTTPStatus.CONFLICT,
+                        detail="A user with the given username or email already exists",
+                    ) from exception
+
+                return await super().handle_exception(exception)
+        """,
+    )
+
+
+def _static_api_key_integration_conftest(*, package_name: str) -> str:
+    return _dedent(
+        f"""
+        import pytest
+        from diwire import Container
+        from throttled.asyncio import MemoryStore
+
+        from {package_name}.infrastructure.throttled.throttler import AsyncThrottlerStoreFactory
+        from {package_name}.ioc.container import get_container
+        from tests.integration.factories import (
+            TestCeleryWorkerFactory,
+            TestClientFactory,
+            TestTasksRegistryFactory,
+            TestUserFactory,
+        )
+
+        _STATIC_API_KEYS = (
+            '{{"test-static-api-key":{{"id":1,"username":"test-static-api-key",'
+            '"email":"test-static-api-key@example.com","first_name":"Test",'
+            '"last_name":"API Key","is_staff":true,"is_superuser":false}}}}'
+        )
+
+
+        @pytest.fixture(scope="function")
+        def container(monkeypatch: pytest.MonkeyPatch) -> Container:
+            monkeypatch.setenv("STATIC_API_KEYS", _STATIC_API_KEYS)
+            container = get_container()
+            container.add_instance(lambda: MemoryStore(), provides=AsyncThrottlerStoreFactory)  # noqa: PLW0108
+
+            return container
+
+
+        # region Factories
+
+
+        @pytest.fixture(scope="function")
+        def test_client_factory(container: Container) -> TestClientFactory:
+            return TestClientFactory(container=container)
+
+
+        @pytest.fixture(scope="function")
+        def user_factory(
+            transactional_db: None,
+            container: Container,
+        ) -> TestUserFactory:
+            return TestUserFactory(container=container)
+
+
+        @pytest.fixture(scope="function")
+        def celery_worker_factory(container: Container) -> TestCeleryWorkerFactory:
+            return TestCeleryWorkerFactory(container=container)
+
+
+        @pytest.fixture(scope="function")
+        def tasks_registry_factory(container: Container) -> TestTasksRegistryFactory:
+            return TestTasksRegistryFactory(container=container)
+
+
+        # endregion Factories
+        """,
+    )
+
+
+def _custom_auth_integration_conftest(*, package_name: str) -> str:
+    return _dedent(
+        f"""
+        import pytest
+        from diwire import Container
+        from throttled.asyncio import MemoryStore
+
+        from {package_name}.infrastructure.throttled.throttler import AsyncThrottlerStoreFactory
+        from {package_name}.ioc.container import get_container
+        from tests.integration.factories import (
+            TestCeleryWorkerFactory,
+            TestClientFactory,
+            TestTasksRegistryFactory,
+            TestUserFactory,
+        )
+
+
+        @pytest.fixture(scope="function")
+        def container() -> Container:
+            container = get_container()
+            container.add_instance(lambda: MemoryStore(), provides=AsyncThrottlerStoreFactory)  # noqa: PLW0108
+
+            return container
+
+
+        # region Factories
+
+
+        @pytest.fixture(scope="function")
+        def test_client_factory(container: Container) -> TestClientFactory:
+            return TestClientFactory(container=container)
+
+
+        @pytest.fixture(scope="function")
+        def user_factory(
+            transactional_db: None,
+            container: Container,
+        ) -> TestUserFactory:
+            return TestUserFactory(container=container)
+
+
+        @pytest.fixture(scope="function")
+        def celery_worker_factory(container: Container) -> TestCeleryWorkerFactory:
+            return TestCeleryWorkerFactory(container=container)
+
+
+        @pytest.fixture(scope="function")
+        def tasks_registry_factory(container: Container) -> TestTasksRegistryFactory:
+            return TestTasksRegistryFactory(container=container)
+
+
+        # endregion Factories
+        """,
+    )
+
+
+def _test_factories_without_jwt(*, package_name: str) -> str:
+    return _dedent(
+        f"""
+        from contextlib import AbstractContextManager
+        from typing import Any
+
+        from celery import Celery
+        from celery.contrib.testing import worker
+        from celery.worker import WorkController
+        from fastapi.testclient import TestClient
+
+        from {package_name}.core.user.models import User
+        from {package_name}.entrypoints.celery.factories import CeleryAppFactory
+        from {package_name}.entrypoints.celery.registry import TasksRegistry
+        from {package_name}.entrypoints.fastapi.factories import FastAPIFactory
+        from tests.foundation.factories import ContainerBasedFactory
+
+
+        class TestClientFactory(ContainerBasedFactory):
+            def __call__(
+                self,
+                headers: dict[str, str] | None = None,
+                **kwargs: Any,
+            ) -> TestClient:
+                api_factory = self._container.resolve(FastAPIFactory)
+
+                app = api_factory(
+                    include_django=False,
+                    add_trusted_hosts_middleware=False,
+                    add_cors_middleware=False,
+                )
+
+                return TestClient(
+                    app=app,
+                    headers=headers,
+                    base_url="http://testserver",
+                    **kwargs,
+                )
+
+
+        class TestUserFactory(ContainerBasedFactory):
+            def __call__(
+                self,
+                username: str = "test_user",
+                password: str = "password123",  # noqa: S107
+                email: str | None = None,
+                *,
+                is_staff: bool = False,
+                **kwargs: Any,
+            ) -> User:
+                email = email or f"{{username}}@test.com"
+
+                return User.objects.create_user(
+                    username=username,
+                    email=email,
+                    password=password,
+                    is_staff=is_staff,
+                    **kwargs,
+                )
+
+
+        class TestCeleryWorkerFactory(ContainerBasedFactory):
+            def __call__(self) -> AbstractContextManager[WorkController]:
+                celery_app_factory = self._container.resolve(CeleryAppFactory)
+                celery_app = celery_app_factory()
+                configure_celery_app_for_tests(celery_app)
+
+                return worker.start_worker(
+                    app=celery_app,
+                    perform_ping_check=False,
+                )
+
+
+        class TestTasksRegistryFactory(ContainerBasedFactory):
+            def __call__(self) -> TasksRegistry:
+                celery_app_factory = self._container.resolve(CeleryAppFactory)
+                configure_celery_app_for_tests(celery_app_factory())
+
+                return self._container.resolve(TasksRegistry)
+
+
+        def configure_celery_app_for_tests(celery_app: Celery) -> None:
+            celery_app.conf.update(
+                broker_url="memory://",
+                result_backend="cache+memory://",
+            )
+        """,
+    )
+
+
+def _static_api_key_integration_auth_test(*, package_name: str) -> str:
+    return _dedent(
+        f"""
+        from http import HTTPStatus
+
+        import pytest
+
+        from {package_name}.core.user.delivery.fastapi.schemas import UserSchema
+        from tests.integration.factories import TestClientFactory
+
+        _TEST_API_KEY = "test-static-api-key"  # noqa: S105
+
+
+        @pytest.mark.django_db(transaction=True)
+        def test_static_api_key_authenticates_current_user_and_skips_token_routes(
+            test_client_factory: TestClientFactory,
+        ) -> None:
+            with test_client_factory(headers={{"X-API-Key": _TEST_API_KEY}}) as test_client:
+                user_response = test_client.get("/v1/users/me")
+                token_response = test_client.post(
+                    "/v1/auth/token",
+                    json={{"username": "service", "password": "unused"}},
+                )
+
+            user_data = UserSchema.model_validate(user_response.json())
+            assert user_response.status_code == HTTPStatus.OK
+            assert user_data.id == 1
+            assert user_data.username == "test-static-api-key"
+            assert token_response.status_code == HTTPStatus.NOT_FOUND
+        """,
+    )
+
+
+def _static_api_key_unit_auth_test(*, package_name: str) -> str:
+    return _dedent(
+        f"""
+        from http import HTTPStatus
+
+        import pytest
+        from fastapi import HTTPException
+        from starlette.requests import Request
+        from starlette.types import Scope
+
+        from {package_name}.core.authentication.delivery.fastapi.auth import (
+            StaticAPIKeyAuth,
+            StaticAPIKeyPrincipal,
+            StaticAPIKeyRegistrySettings,
+        )
+
+
+        def test_static_api_key_registry_parses_json_environment(
+            monkeypatch: pytest.MonkeyPatch,
+        ) -> None:
+            monkeypatch.setenv(
+                "STATIC_API_KEYS",
+                (
+                    '{{"env-key":{{"id":7,"username":"service","email":"service@example.com",'
+                    '"is_staff":true,"is_superuser":false}}}}'
+                ),
+            )
+
+            settings = StaticAPIKeyRegistrySettings()
+
+            principal = settings.get_principal_for_api_key(api_key="env-key")
+            assert principal is not None
+            assert principal.pk == 7
+            assert principal.username == "service"
+            assert principal.is_staff is True
+
+
+        @pytest.mark.anyio
+        async def test_static_api_key_auth_sets_request_user() -> None:
+            settings = _settings(is_staff=True)
+            request = _request(headers={{"X-API-Key": "valid-key"}})
+            auth = StaticAPIKeyAuth(settings=settings)
+
+            api_key = await auth(request)
+
+            assert api_key == "valid-key"
+            assert request.state.user.username == "service"
+            assert request.state.user.pk == 1
+
+
+        @pytest.mark.anyio
+        async def test_static_api_key_auth_rejects_missing_key() -> None:
+            auth = StaticAPIKeyAuth(settings=_settings())
+
+            with pytest.raises(HTTPException) as error:
+                await auth(_request())
+
+            assert error.value.status_code == HTTPStatus.UNAUTHORIZED
+            assert error.value.detail == "API key is required"
+
+
+        @pytest.mark.anyio
+        async def test_static_api_key_auth_rejects_invalid_key() -> None:
+            auth = StaticAPIKeyAuth(settings=_settings())
+
+            with pytest.raises(HTTPException) as error:
+                await auth(_request(headers={{"X-API-Key": "invalid-key"}}))
+
+            assert error.value.status_code == HTTPStatus.UNAUTHORIZED
+            assert error.value.detail == "Invalid API key"
+
+
+        @pytest.mark.anyio
+        async def test_static_api_key_auth_checks_staff_permission() -> None:
+            auth = StaticAPIKeyAuth(settings=_settings(is_staff=False), require_staff=True)
+
+            with pytest.raises(HTTPException) as error:
+                await auth(_request(headers={{"X-API-Key": "valid-key"}}))
+
+            assert error.value.status_code == HTTPStatus.FORBIDDEN
+            assert error.value.detail == "Staff access required"
+
+
+        def _settings(*, is_staff: bool = False) -> StaticAPIKeyRegistrySettings:
+            return StaticAPIKeyRegistrySettings(
+                api_keys={{
+                    "valid-key": StaticAPIKeyPrincipal(
+                        id=1,
+                        username="service",
+                        email="service@example.com",
+                        is_staff=is_staff,
+                        is_superuser=False,
+                    ),
+                }},
+            )
+
+
+        def _request(*, headers: dict[str, str] | None = None) -> Request:
+            header_items = [
+                (key.lower().encode(), value.encode()) for key, value in (headers or {{}}).items()
+            ]
+            scope: Scope = {{
+                "type": "http",
+                "method": "GET",
+                "path": "/",
+                "raw_path": b"/",
+                "query_string": b"",
+                "headers": header_items,
+                "client": ("testclient", 50000),
+                "server": ("testserver", 80),
+                "scheme": "http",
+            }}
+            return Request(scope)
+        """,
+    )
+
+
+def _static_api_key_user_controller_test(*, package_name: str) -> str:
+    return _dedent(
+        f"""
+        from http import HTTPStatus
+
+        import pytest
+
+        from {package_name}.core.user.delivery.fastapi.schemas import UserSchema
+        from {package_name}.core.user.models import User
+        from tests.integration.factories import TestClientFactory, TestUserFactory
+
+        _TEST_API_KEY = "test-static-api-key"  # noqa: S105
+        _TEST_PASSWORD = "test-password"  # noqa: S105
+
+
+        @pytest.fixture(scope="function")
+        def user(user_factory: TestUserFactory) -> User:
+            return user_factory(username="test", password=_TEST_PASSWORD)
+
+
+        @pytest.mark.django_db(transaction=True)
+        class TestUserController:
+            def test_create_user(self, test_client_factory: TestClientFactory) -> None:
+                with test_client_factory() as test_client:
+                    response = test_client.post(
+                        "/v1/users/",
+                        json={{
+                            "username": "test_new_user",
+                            "email": "new_user@test.com",
+                            "password": _TEST_PASSWORD,
+                            "first_name": "Test",
+                            "last_name": "User",
+                        }},
+                    )
+
+                response_data = UserSchema.model_validate(response.json())
+                assert response.status_code == HTTPStatus.OK
+                assert response_data.username == "test_new_user"
+
+            def test_auth_for_static_api_key(
+                self,
+                test_client_factory: TestClientFactory,
+            ) -> None:
+                with test_client_factory(headers={{"X-API-Key": _TEST_API_KEY}}) as test_client:
+                    response = test_client.get("/v1/users/me")
+
+                user_data = UserSchema.model_validate(response.json())
+                assert response.status_code == HTTPStatus.OK
+                assert user_data.username == "test-static-api-key"
+
+            def test_staff_static_api_key_for_user(
+                self,
+                test_client_factory: TestClientFactory,
+                user_factory: TestUserFactory,
+            ) -> None:
+                other_user = user_factory(username="other_user")
+                with test_client_factory(headers={{"X-API-Key": _TEST_API_KEY}}) as test_client:
+                    response = test_client.get(f"/v1/users/{{other_user.pk}}")
+
+                assert response.status_code == HTTPStatus.OK
+        """,
+    )
+
+
+def _custom_auth_user_controller_test(*, package_name: str) -> str:
+    return _dedent(
+        f"""
+        from http import HTTPStatus
+
+        import pytest
+
+        from {package_name}.core.user.delivery.fastapi.schemas import UserSchema
+        from tests.integration.factories import TestClientFactory
+
+        _TEST_PASSWORD = "test-password"  # noqa: S105
+
+
+        @pytest.mark.django_db(transaction=True)
+        class TestUserController:
+            def test_create_user(self, test_client_factory: TestClientFactory) -> None:
+                with test_client_factory() as test_client:
+                    response = test_client.post(
+                        "/v1/users/",
+                        json={{
+                            "username": "test_new_user",
+                            "email": "new_user@test.com",
+                            "password": _TEST_PASSWORD,
+                            "first_name": "Test",
+                            "last_name": "User",
+                        }},
+                    )
+
+                response_data = UserSchema.model_validate(response.json())
+                assert response.status_code == HTTPStatus.OK
+                assert response_data.username == "test_new_user"
+        """,
+    )
+
+
 def _plan_config_rewrites(
     *,
     plan: FilePlan,
@@ -211,7 +1342,7 @@ def _plan_environment_files(*, plan: FilePlan, answers: SetupAnswers) -> None:
     )
     plan.add_write(
         plan.repo_root / ".env.test.example",
-        content=build_test_env_example_content(),
+        content=build_test_env_example_content(answers=answers),
         detail="Update .env.test.example",
     )
 
@@ -417,6 +1548,10 @@ def _is_wizard_path(*, path: Path, repo_root: Path) -> bool:
         return True
 
     return False
+
+
+def _dedent(value: str) -> str:
+    return textwrap.dedent(value).lstrip()
 
 
 type ConfigRewrite = Callable[[str], str]

--- a/management/setup_wizard/prompts.py
+++ b/management/setup_wizard/prompts.py
@@ -11,7 +11,13 @@ from urllib.parse import urlsplit
 
 import questionary
 
-from management.setup_wizard.models import DatabaseMode, RedisMode, SetupAnswers, StorageMode
+from management.setup_wizard.models import (
+    AuthenticationMode,
+    DatabaseMode,
+    RedisMode,
+    SetupAnswers,
+    StorageMode,
+)
 
 PACKAGE_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
 DISTRIBUTION_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*[a-z0-9]$")
@@ -102,6 +108,7 @@ def prompt_for_answers(*, repo_root: Path) -> SetupAnswers:
     database_answers = _ask_database_answers(database_mode=database_mode)
     redis_mode = _ask_redis_mode()
     redis_answers = _ask_redis_answers(redis_mode=redis_mode)
+    authentication_mode = _ask_authentication_mode()
     public_origin_answers = _ask_public_origin_answers()
     logfire_answers = _ask_logfire_answers()
     delete_wizard = _ask_confirm("Delete setup wizard after setup?", default=True)
@@ -115,6 +122,7 @@ def prompt_for_answers(*, repo_root: Path) -> SetupAnswers:
         storage_mode=storage_mode,
         database_mode=database_mode,
         redis_mode=redis_mode,
+        authentication_mode=authentication_mode,
         keep_docs=keep_docs,
         delete_wizard=delete_wizard,
         overwrite_env=overwrite_env,
@@ -222,6 +230,31 @@ def _ask_redis_answers(*, redis_mode: RedisMode) -> RedisPromptAnswers:
     return RedisPromptAnswers(
         redis_port=_ask_int("Redis host port", default=6379),
     )
+
+
+def _ask_authentication_mode() -> AuthenticationMode:
+    value = questionary.select(
+        "Authentication / authorization",
+        choices=[
+            questionary.Choice(
+                "JWT access tokens with refresh sessions",
+                AuthenticationMode.JWT_REFRESH_SESSION,
+            ),
+            questionary.Choice(
+                "Static API keys from environment JSON",
+                AuthenticationMode.STATIC_API_KEYS,
+            ),
+            questionary.Choice(
+                "Custom implementation later",
+                AuthenticationMode.CUSTOM,
+            ),
+        ],
+        default=AuthenticationMode.JWT_REFRESH_SESSION,
+    ).ask()
+    if value is None:
+        raise KeyboardInterrupt
+
+    return cast(AuthenticationMode, value)
 
 
 def _ask_storage_answers(*, storage_mode: StorageMode) -> StoragePromptAnswers:

--- a/management/setup_wizard/readme.py
+++ b/management/setup_wizard/readme.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from management.setup_wizard.models import DatabaseMode, RedisMode, SetupAnswers, StorageMode
+from management.setup_wizard.models import (
+    AuthenticationMode,
+    DatabaseMode,
+    RedisMode,
+    SetupAnswers,
+    StorageMode,
+)
 
 FASTDJANGO_TEMPLATE_URL = "https://github.com/maksimzayats/fastdjango"
 
@@ -73,6 +79,7 @@ def build_project_readme(*, answers: SetupAnswers) -> str:  # noqa: PLR0912
             f"- Database: {_database_label(answers=answers)}",
             f"- Redis: {_redis_label(answers=answers)}",
             f"- Storage: {_storage_label(answers=answers)}",
+            f"- Authentication: {_authentication_label(answers=answers)}",
             f"- Logfire: {'enabled' if answers.enable_logfire else 'disabled'}",
             "",
         ],
@@ -163,3 +170,13 @@ def _storage_label(*, answers: SetupAnswers) -> str:
         return f"local MinIO on ports {answers.minio_api_port} and {answers.minio_console_port}"
 
     return "remote S3-compatible storage"
+
+
+def _authentication_label(*, answers: SetupAnswers) -> str:
+    if answers.authentication_mode == AuthenticationMode.JWT_REFRESH_SESSION:
+        return "JWT access tokens with refresh sessions"
+
+    if answers.authentication_mode == AuthenticationMode.STATIC_API_KEYS:
+        return "static API keys from environment JSON"
+
+    return "custom implementation"

--- a/src/fastdjango/core/authentication/delivery/fastapi/auth.py
+++ b/src/fastdjango/core/authentication/delivery/fastapi/auth.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
+import secrets
 from dataclasses import dataclass
+from enum import StrEnum
 from http import HTTPStatus
 from typing import Any, cast
 
 from diwire import Injected
 from fastapi import HTTPException
 from fastapi.requests import Request
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from starlette.datastructures import State
 
 from fastdjango.core.authentication.services.jwt import JWTService
@@ -14,13 +20,84 @@ from fastdjango.core.user.use_cases import UserUseCase
 from fastdjango.foundation.factories import BaseFactory
 
 
+class AuthenticationMode(StrEnum):
+    JWT_REFRESH_SESSION = "jwt-refresh-session"
+    STATIC_API_KEYS = "static-api-keys"
+    CUSTOM = "custom"
+
+
+class AuthenticationSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="AUTHENTICATION_")
+
+    mode: AuthenticationMode = AuthenticationMode.JWT_REFRESH_SESSION
+
+
+class StaticAPIKeyPrincipal(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    id: int
+    username: str
+    email: EmailStr
+    first_name: str = ""
+    last_name: str = ""
+    is_staff: bool = False
+    is_superuser: bool = False
+
+    @property
+    def pk(self) -> int:
+        return self.id
+
+
+class StaticAPIKeyRegistrySettings(BaseSettings):
+    model_config = SettingsConfigDict(populate_by_name=True)
+
+    api_keys: dict[str, StaticAPIKeyPrincipal] = Field(
+        default_factory=dict,
+        validation_alias="STATIC_API_KEYS",
+    )
+
+    def get_principal_for_api_key(self, *, api_key: str) -> StaticAPIKeyPrincipal | None:
+        for registered_api_key, principal in self.api_keys.items():
+            if secrets.compare_digest(api_key, registered_api_key):
+                return principal
+
+        return None
+
+
 class AuthenticatedRequestState(State):
     jwt_payload: dict[str, Any]
-    user: User
+    user: User | StaticAPIKeyPrincipal
 
 
 class AuthenticatedRequest(Request):
     state: AuthenticatedRequestState
+
+
+@dataclass(kw_only=True)
+class AccessAuthFactory(BaseFactory):
+    _authentication_settings: Injected[AuthenticationSettings]
+    _jwt_auth_factory: Injected[JWTAuthFactory]
+    _static_api_key_auth_factory: Injected[StaticAPIKeyAuthFactory]
+
+    def __call__(
+        self,
+        *,
+        require_staff: bool = False,
+        require_superuser: bool = False,
+    ) -> JWTAuth | StaticAPIKeyAuth | AuthenticationNotConfiguredAuth:
+        if self._authentication_settings.mode == AuthenticationMode.JWT_REFRESH_SESSION:
+            return self._jwt_auth_factory(
+                require_staff=require_staff,
+                require_superuser=require_superuser,
+            )
+
+        if self._authentication_settings.mode == AuthenticationMode.STATIC_API_KEYS:
+            return self._static_api_key_auth_factory(
+                require_staff=require_staff,
+                require_superuser=require_superuser,
+            )
+
+        return AuthenticationNotConfiguredAuth()
 
 
 @dataclass(kw_only=True)
@@ -61,6 +138,23 @@ class JWTAuthFactory(BaseFactory):
             )
 
         return JWTAuth(jwt_service=self._jwt_service, user_use_case=self._user_use_case)
+
+
+@dataclass(kw_only=True)
+class StaticAPIKeyAuthFactory(BaseFactory):
+    _settings: Injected[StaticAPIKeyRegistrySettings]
+
+    def __call__(
+        self,
+        *,
+        require_staff: bool = False,
+        require_superuser: bool = False,
+    ) -> StaticAPIKeyAuth:
+        return StaticAPIKeyAuth(
+            settings=self._settings,
+            require_staff=require_staff,
+            require_superuser=require_superuser,
+        )
 
 
 class JWTAuth(HTTPBearer):
@@ -115,6 +209,65 @@ class JWTAuth(HTTPBearer):
                 status_code=HTTPStatus.UNAUTHORIZED,
                 detail="Invalid token",
             ) from e
+
+
+class StaticAPIKeyAuth(APIKeyHeader):
+    def __init__(
+        self,
+        settings: StaticAPIKeyRegistrySettings,
+        *,
+        require_staff: bool = False,
+        require_superuser: bool = False,
+    ) -> None:
+        super().__init__(name="X-API-Key", auto_error=False)
+        self._settings = settings
+        self._require_staff = require_staff
+        self._require_superuser = require_superuser
+
+    async def __call__(self, request: Request) -> str | None:
+        api_key = await super().__call__(request)
+        if api_key is None:
+            raise HTTPException(
+                status_code=HTTPStatus.UNAUTHORIZED,
+                detail="API key is required",
+            )
+
+        principal = self._settings.get_principal_for_api_key(api_key=api_key)
+        if principal is None:
+            raise HTTPException(
+                status_code=HTTPStatus.UNAUTHORIZED,
+                detail="Invalid API key",
+            )
+
+        self._check_permissions(principal=principal)
+        request = cast(AuthenticatedRequest, request)
+        request.state.user = principal
+
+        return api_key
+
+    def _check_permissions(self, *, principal: StaticAPIKeyPrincipal) -> None:
+        if self._require_staff and not principal.is_staff:
+            raise HTTPException(
+                status_code=HTTPStatus.FORBIDDEN,
+                detail="Staff access required",
+            )
+
+        if self._require_superuser and not principal.is_superuser:
+            raise HTTPException(
+                status_code=HTTPStatus.FORBIDDEN,
+                detail="Superuser access required",
+            )
+
+
+class AuthenticationNotConfiguredAuth(HTTPBearer):
+    def __init__(self) -> None:
+        super().__init__(auto_error=False)
+
+    async def __call__(self, _request: Request) -> HTTPAuthorizationCredentials | None:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_IMPLEMENTED,
+            detail="Authentication is not configured",
+        )
 
 
 class JWTAuthWithPermissions(JWTAuth):

--- a/src/fastdjango/core/authentication/delivery/fastapi/controllers.py
+++ b/src/fastdjango/core/authentication/delivery/fastapi/controllers.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from http import HTTPStatus
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from diwire import Injected
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -21,6 +23,9 @@ from fastdjango.core.authentication.use_cases import TokenUseCase
 from fastdjango.core.shared.delivery.fastapi.request import RequestInfoService
 from fastdjango.core.shared.delivery.fastapi.throttling import IPThrottlerFactory
 from fastdjango.foundation.delivery.controllers import BaseAsyncController
+
+if TYPE_CHECKING:
+    from fastdjango.core.user.models import User
 
 
 @dataclass(kw_only=True)
@@ -101,7 +106,7 @@ class AuthenticationTokenController(BaseAsyncController):
     ) -> None:
         await self._token_use_case.revoke_token(
             data=body,
-            user=request.state.user,
+            user=cast("User", request.state.user),
         )
 
     async def handle_exception(self, exception: Exception) -> Any:

--- a/src/fastdjango/core/authentication/services/jwt.py
+++ b/src/fastdjango/core/authentication/services/jwt.py
@@ -13,7 +13,7 @@ from fastdjango.foundation.services import BaseService
 class JWTServiceSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="JWT_")
 
-    secret_key: SecretStr
+    secret_key: SecretStr | None = None
     algorithm: str = "HS256"
     typ: str = "at+jwt"
     access_token_expire_minutes: int = 15
@@ -27,6 +27,7 @@ class JWTServiceSettings(BaseSettings):
 class JWTService(BaseService):
     EXPIRED_SIGNATURE_ERROR: ClassVar = jwt.ExpiredSignatureError
     INVALID_TOKEN_ERROR: ClassVar = jwt.InvalidTokenError
+    MISSING_SECRET_KEY_ERROR: ClassVar = ValueError
 
     _settings: Injected[JWTServiceSettings]
 
@@ -47,13 +48,21 @@ class JWTService(BaseService):
 
         return jwt.encode(
             payload=payload,
-            key=self._settings.secret_key.get_secret_value(),
+            key=self._secret_key,
             algorithm=self._settings.algorithm,
         )
 
     def decode_token(self, *, token: str) -> dict[str, Any]:
         return jwt.decode(
             jwt=token,
-            key=self._settings.secret_key.get_secret_value(),
+            key=self._secret_key,
             algorithms=[self._settings.algorithm],
         )
+
+    @property
+    def _secret_key(self) -> str:
+        if self._settings.secret_key is None:
+            msg = "JWT_SECRET_KEY is required when AUTHENTICATION_MODE=jwt-refresh-session."
+            raise self.MISSING_SECRET_KEY_ERROR(msg)
+
+        return self._settings.secret_key.get_secret_value()

--- a/src/fastdjango/core/user/delivery/fastapi/controllers.py
+++ b/src/fastdjango/core/user/delivery/fastapi/controllers.py
@@ -6,8 +6,10 @@ from diwire import Injected
 from fastapi import APIRouter, Depends, HTTPException
 
 from fastdjango.core.authentication.delivery.fastapi.auth import (
+    AccessAuthFactory,
     AuthenticatedRequest,
-    JWTAuthFactory,
+    AuthenticationMode,
+    AuthenticationSettings,
 )
 from fastdjango.core.user.delivery.fastapi.schemas import (
     CreateUserRequestSchema,
@@ -19,12 +21,13 @@ from fastdjango.foundation.delivery.controllers import BaseAsyncController
 
 @dataclass(kw_only=True)
 class UserController(BaseAsyncController):
-    _jwt_auth_factory: Injected[JWTAuthFactory]
+    _access_auth_factory: Injected[AccessAuthFactory]
+    _authentication_settings: Injected[AuthenticationSettings]
     _user_use_case: Injected[UserUseCase]
 
     def __post_init__(self) -> None:
-        self._jwt_auth = self._jwt_auth_factory()
-        self._staff_jwt_auth = self._jwt_auth_factory(require_staff=True)
+        self._auth = self._access_auth_factory()
+        self._staff_auth = self._access_auth_factory(require_staff=True)
         super().__post_init__()
 
     def register(self, registry: APIRouter) -> None:
@@ -35,11 +38,14 @@ class UserController(BaseAsyncController):
             response_model=UserSchema,
         )
 
+        if self._authentication_settings.mode == AuthenticationMode.CUSTOM:
+            return
+
         registry.add_api_route(
             path="/v1/users/me",
             endpoint=self.get_current_user,
             methods=["GET"],
-            dependencies=[Depends(self._jwt_auth)],
+            dependencies=[Depends(self._auth)],
             response_model=UserSchema,
         )
 
@@ -47,7 +53,7 @@ class UserController(BaseAsyncController):
             path="/v1/users/{user_id}",
             endpoint=self.get_user_by_id,
             methods=["GET"],
-            dependencies=[Depends(self._staff_jwt_auth)],
+            dependencies=[Depends(self._staff_auth)],
             response_model=UserSchema,
         )
 

--- a/src/fastdjango/entrypoints/fastapi/factories.py
+++ b/src/fastdjango/entrypoints/fastapi/factories.py
@@ -13,6 +13,10 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.types import ASGIApp
 
+from fastdjango.core.authentication.delivery.fastapi.auth import (
+    AuthenticationMode,
+    AuthenticationSettings,
+)
 from fastdjango.core.authentication.delivery.fastapi.controllers import (
     AuthenticationTokenController,
 )
@@ -53,6 +57,7 @@ class Lifespan:
 @dataclass(kw_only=True)
 class FastAPIFactory(BaseFactory):
     _application_settings: Injected[ApplicationSettings]
+    _authentication_settings: Injected[AuthenticationSettings]
     _fastapi_settings: Injected[FastAPISettings]
     _cors_settings: Injected[CORSSettings]
 
@@ -129,9 +134,10 @@ class FastAPIFactory(BaseFactory):
         self._health_controller.register(health_router)
         app.include_router(health_router)
 
-        auth_router = APIRouter(tags=["auth", "token"])
-        self._authentication_token_controller.register(auth_router)
-        app.include_router(auth_router)
+        if self._authentication_settings.mode == AuthenticationMode.JWT_REFRESH_SESSION:
+            auth_router = APIRouter(tags=["auth", "token"])
+            self._authentication_token_controller.register(auth_router)
+            app.include_router(auth_router)
 
         user_router = APIRouter(tags=["user"])
         self._user_controller.register(user_router)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,7 +13,10 @@ from tests.integration.factories import (
 
 
 @pytest.fixture(scope="function")
-def container() -> Container:
+def container(monkeypatch: pytest.MonkeyPatch) -> Container:
+    monkeypatch.setenv("AUTHENTICATION_MODE", "jwt-refresh-session")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-jwt-secret-key-with-at-least-32-bytes")
+
     container = get_container()
     container.add_instance(lambda: MemoryStore(), provides=AsyncThrottlerStoreFactory)  # noqa: PLW0108
 

--- a/tests/integration/core/authentication/delivery/fastapi/test_auth.py
+++ b/tests/integration/core/authentication/delivery/fastapi/test_auth.py
@@ -1,0 +1,61 @@
+from http import HTTPStatus
+
+import pytest
+from throttled.asyncio import MemoryStore
+
+from fastdjango.core.user.delivery.fastapi.schemas import UserSchema
+from fastdjango.infrastructure.throttled.throttler import AsyncThrottlerStoreFactory
+from fastdjango.ioc.container import get_container
+from tests.integration.factories import TestClientFactory
+
+
+@pytest.mark.django_db(transaction=True)
+def test_static_api_key_mode_authenticates_current_user_and_skips_token_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AUTHENTICATION_MODE", "static-api-keys")
+    monkeypatch.setenv(
+        "STATIC_API_KEYS",
+        (
+            '{"test-static-key":{"id":42,"username":"service","email":"service@example.com",'
+            '"first_name":"Service","last_name":"Account","is_staff":true,'
+            '"is_superuser":false}}'
+        ),
+    )
+    container = get_container()
+    container.add_instance(lambda: MemoryStore(), provides=AsyncThrottlerStoreFactory)  # noqa: PLW0108
+    test_client_factory = TestClientFactory(container=container)
+
+    with test_client_factory(headers={"X-API-Key": "test-static-key"}) as test_client:
+        user_response = test_client.get("/v1/users/me")
+        token_response = test_client.post(
+            "/v1/auth/token",
+            json={"username": "service", "password": "unused"},
+        )
+
+    user_data = UserSchema.model_validate(user_response.json())
+    assert user_response.status_code == HTTPStatus.OK
+    assert user_data.id == 42
+    assert user_data.username == "service"
+    assert user_data.email == "service@example.com"
+    assert token_response.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.django_db(transaction=True)
+def test_custom_authentication_mode_skips_built_in_protected_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AUTHENTICATION_MODE", "custom")
+    container = get_container()
+    container.add_instance(lambda: MemoryStore(), provides=AsyncThrottlerStoreFactory)  # noqa: PLW0108
+    test_client_factory = TestClientFactory(container=container)
+
+    with test_client_factory() as test_client:
+        user_response = test_client.get("/v1/users/me")
+        token_response = test_client.post(
+            "/v1/auth/token",
+            json={"username": "service", "password": "unused"},
+        )
+
+    assert user_response.status_code == HTTPStatus.NOT_FOUND
+    assert token_response.status_code == HTTPStatus.NOT_FOUND

--- a/tests/setup_wizard/test_planner.py
+++ b/tests/setup_wizard/test_planner.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+import ast
 import textwrap
 import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from management.setup_wizard.models import DatabaseMode, RedisMode, SetupAnswers, StorageMode
+from management.setup_wizard.models import (
+    AuthenticationMode,
+    DatabaseMode,
+    RedisMode,
+    SetupAnswers,
+    StorageMode,
+)
 from management.setup_wizard.planner import build_setup_plan
 
 
@@ -232,6 +239,7 @@ def test_generated_env_files_are_grouped_by_concern(tmp_path: Path) -> None:
             "# Compose\n",
             "\n# Application\n",
             "\n# Secrets\n",
+            "\n# Authentication\n",
             "\n# HTTP\n",
             "\n# Observability\n",
             "\n# Database\n",
@@ -245,6 +253,7 @@ def test_generated_env_files_are_grouped_by_concern(tmp_path: Path) -> None:
         markers=(
             "# Application\n",
             "\n# Secrets\n",
+            "\n# Authentication\n",
             "\n# Observability\n",
             "\n# Database\n",
             "\n# Redis\n",
@@ -253,6 +262,139 @@ def test_generated_env_files_are_grouped_by_concern(tmp_path: Path) -> None:
     )
     assert "\n\n# Database\n" in env_example_content
     assert "\n\n# Database\n" in test_env_example_content
+
+
+def test_static_api_key_authentication_writes_json_registry_without_jwt_secret(
+    tmp_path: Path,
+) -> None:
+    _create_mini_repo(repo_root=tmp_path)
+    answers = _answers(
+        authentication_mode=AuthenticationMode.STATIC_API_KEYS,
+        delete_wizard=False,
+    )
+
+    build_setup_plan(repo_root=tmp_path, answers=answers).apply(run_commands=False)
+
+    env_content = (tmp_path / ".env").read_text()
+    env_example_content = (tmp_path / ".env.example").read_text()
+    test_env_example_content = (tmp_path / ".env.test.example").read_text()
+    readme = (tmp_path / "README.md").read_text()
+
+    assert "AUTHENTICATION_MODE=static-api-keys" in env_content
+    assert "JWT_SECRET_KEY" not in env_content
+    assert '"local-api-key@example.com"' in env_content
+    assert "AUTHENTICATION_MODE=static-api-keys" in env_example_content
+    assert 'STATIC_API_KEYS={"example-static-api-key":' in env_example_content
+    assert "AUTHENTICATION_MODE=static-api-keys" in test_env_example_content
+    assert 'STATIC_API_KEYS={"test-static-api-key":' in test_env_example_content
+    assert "- Authentication: static API keys from environment JSON" in readme
+
+
+def test_static_api_key_authentication_prunes_refresh_session_code(tmp_path: Path) -> None:
+    _create_mini_repo(repo_root=tmp_path)
+    answers = _answers(
+        authentication_mode=AuthenticationMode.STATIC_API_KEYS,
+        delete_wizard=False,
+    )
+
+    build_setup_plan(repo_root=tmp_path, answers=answers).apply(run_commands=False)
+
+    package_root = tmp_path / "src" / "example_api"
+    auth_root = package_root / "core" / "authentication"
+    auth_dependency = (auth_root / "delivery" / "fastapi" / "auth.py").read_text()
+    settings = (package_root / "infrastructure" / "django" / "settings.py").read_text()
+    user_model = (package_root / "core" / "user" / "models.py").read_text()
+    fastapi_factory = (package_root / "entrypoints" / "fastapi" / "factories.py").read_text()
+    user_controller = (
+        package_root / "core" / "user" / "delivery" / "fastapi" / "controllers.py"
+    ).read_text()
+    test_factories = (tmp_path / "tests" / "integration" / "factories.py").read_text()
+
+    _assert_python_files_parse(root=package_root)
+    _assert_python_files_parse(root=tmp_path / "tests")
+
+    assert "StaticAPIKeyAuth" in auth_dependency
+    assert "JWTService" not in auth_dependency
+    assert "JWTAuthFactory" not in auth_dependency
+    assert "AuthenticationConfig" not in settings
+    assert "RefreshSession" not in user_model
+    assert "refresh_sessions" not in user_model
+    assert "AuthenticationTokenController" not in fastapi_factory
+    assert "StaticAPIKeyAuthFactory" in user_controller
+    assert "JWTAuthFactory" not in user_controller
+    assert "JWTService" not in test_factories
+    assert not (auth_root / "models.py").exists()
+    assert not (auth_root / "use_cases.py").exists()
+    assert not (auth_root / "services").exists()
+    assert not (auth_root / "migrations").exists()
+    assert not (auth_root / "delivery" / "fastapi" / "controllers.py").exists()
+    assert not (
+        tmp_path
+        / "tests"
+        / "integration"
+        / "core"
+        / "authentication"
+        / "delivery"
+        / "fastapi"
+        / "test_controllers.py"
+    ).exists()
+    assert not (tmp_path / "tests" / "unit" / "core" / "authentication" / "services").exists()
+
+
+def test_custom_authentication_skips_generated_auth_secrets(tmp_path: Path) -> None:
+    _create_mini_repo(repo_root=tmp_path)
+    answers = _answers(
+        authentication_mode=AuthenticationMode.CUSTOM,
+        delete_wizard=False,
+    )
+
+    build_setup_plan(repo_root=tmp_path, answers=answers).apply(run_commands=False)
+
+    env_content = (tmp_path / ".env").read_text()
+    test_env_example_content = (tmp_path / ".env.test.example").read_text()
+
+    assert "AUTHENTICATION_MODE=custom" in env_content
+    assert "AUTHENTICATION_MODE=custom" in test_env_example_content
+    assert "JWT_SECRET_KEY" not in env_content
+    assert "STATIC_API_KEYS" not in env_content
+
+
+def test_custom_authentication_prunes_built_in_authentication_code(tmp_path: Path) -> None:
+    _create_mini_repo(repo_root=tmp_path)
+    answers = _answers(
+        authentication_mode=AuthenticationMode.CUSTOM,
+        delete_wizard=False,
+    )
+
+    build_setup_plan(repo_root=tmp_path, answers=answers).apply(run_commands=False)
+
+    package_root = tmp_path / "src" / "example_api"
+    settings = (package_root / "infrastructure" / "django" / "settings.py").read_text()
+    fastapi_factory = (package_root / "entrypoints" / "fastapi" / "factories.py").read_text()
+    user_controller = (
+        package_root / "core" / "user" / "delivery" / "fastapi" / "controllers.py"
+    ).read_text()
+    user_controller_test = (
+        tmp_path
+        / "tests"
+        / "integration"
+        / "core"
+        / "user"
+        / "delivery"
+        / "fastapi"
+        / "test_controllers.py"
+    ).read_text()
+
+    _assert_python_files_parse(root=package_root)
+    _assert_python_files_parse(root=tmp_path / "tests")
+
+    assert not (package_root / "core" / "authentication").exists()
+    assert not (tmp_path / "tests" / "integration" / "core" / "authentication").exists()
+    assert not (tmp_path / "tests" / "unit" / "core" / "authentication").exists()
+    assert "AuthenticationConfig" not in settings
+    assert "authentication" not in fastapi_factory
+    assert "authentication" not in user_controller
+    assert "/v1/users/me" not in user_controller_test
 
 
 def test_docs_removal_deletes_docs_config_targets_and_links(tmp_path: Path) -> None:
@@ -288,6 +430,7 @@ def _answers(
     storage_mode: StorageMode = StorageMode.LOCAL,
     database_mode: DatabaseMode = DatabaseMode.DOCKER_POSTGRES,
     redis_mode: RedisMode = RedisMode.DOCKER_REDIS,
+    authentication_mode: AuthenticationMode = AuthenticationMode.JWT_REFRESH_SESSION,
     keep_docs: bool = True,
     delete_wizard: bool = True,
     repo_url: str | None = None,
@@ -316,6 +459,7 @@ def _answers(
         storage_mode=storage_mode,
         database_mode=database_mode,
         redis_mode=redis_mode,
+        authentication_mode=authentication_mode,
         keep_docs=keep_docs,
         delete_wizard=delete_wizard,
         overwrite_env=True,
@@ -358,6 +502,7 @@ def _create_mini_repo(*, repo_root: Path) -> None:
         repo_root / "tests" / "sample_test.py",
         "from fastdjango.core.sample import SampleService\n",
     )
+    _create_authentication_files(repo_root=repo_root)
     _write(repo_root / "management" / "setup_wizard" / "__init__.py", "")
     _write(repo_root / "tests" / "setup_wizard" / "test_old.py", "")
     _write(
@@ -382,6 +527,210 @@ def _create_mini_repo(*, repo_root: Path) -> None:
     _write(repo_root / "docker" / "docker-compose.yaml", _compose_content())
     _write(repo_root / "docker" / "docker-compose.local.yaml", _compose_overlay_content())
     _write(repo_root / "docker" / "docker-compose.test.yaml", _compose_overlay_content())
+
+
+def _create_authentication_files(*, repo_root: Path) -> None:
+    _write(
+        repo_root / "src" / "fastdjango" / "infrastructure" / "django" / "settings.py",
+        """
+        INSTALLED_APPS = [
+            "fastdjango.core.authentication.apps.AuthenticationConfig",
+            "fastdjango.core.user.apps.UserConfig",
+        ]
+        """,
+    )
+    _write(
+        repo_root / "src" / "fastdjango" / "core" / "user" / "models.py",
+        """
+        from __future__ import annotations
+
+        from typing import TYPE_CHECKING
+
+        from django.contrib.auth.models import AbstractUser
+        from django.db import models
+
+        if TYPE_CHECKING:
+            from fastdjango.core.authentication.models import RefreshSession
+
+
+        class User(AbstractUser):
+            refresh_sessions: "models.Manager[RefreshSession]"  # noqa: UP037
+
+            email = models.EmailField(verbose_name="email address", unique=True)
+
+            def __str__(self) -> str:
+                return f"User(id={self.pk}, username={self.username})"
+        """,
+    )
+    _write(
+        repo_root
+        / "src"
+        / "fastdjango"
+        / "core"
+        / "user"
+        / "delivery"
+        / "fastapi"
+        / "controllers.py",
+        """
+        from dataclasses import dataclass
+
+        from diwire import Injected
+        from fastapi import APIRouter, Depends
+
+        from fastdjango.core.authentication.delivery.fastapi.auth import (
+            AuthenticatedRequest,
+            JWTAuthFactory,
+        )
+        from fastdjango.core.user.delivery.fastapi.schemas import UserSchema
+        from fastdjango.foundation.delivery.controllers import BaseAsyncController
+
+
+        @dataclass(kw_only=True)
+        class UserController(BaseAsyncController):
+            _jwt_auth_factory: Injected[JWTAuthFactory]
+
+            def register(self, registry: APIRouter) -> None:
+                registry.add_api_route(
+                    path="/v1/users/me",
+                    endpoint=self.get_current_user,
+                    methods=["GET"],
+                    dependencies=[Depends(self._jwt_auth_factory())],
+                    response_model=UserSchema,
+                )
+
+            async def get_current_user(self, request: AuthenticatedRequest) -> UserSchema:
+                return UserSchema.model_validate(request.state.user, from_attributes=True)
+        """,
+    )
+    _write(
+        repo_root / "src" / "fastdjango" / "entrypoints" / "fastapi" / "factories.py",
+        """
+        from dataclasses import dataclass
+
+        from diwire import Injected
+        from fastapi import APIRouter, FastAPI
+
+        from fastdjango.core.authentication.delivery.fastapi.controllers import (
+            AuthenticationTokenController,
+        )
+        from fastdjango.core.user.delivery.fastapi.controllers import UserController
+        from fastdjango.foundation.factories import BaseFactory
+
+
+        @dataclass(kw_only=True)
+        class FastAPIFactory(BaseFactory):
+            _authentication_token_controller: Injected[AuthenticationTokenController]
+            _user_controller: Injected[UserController]
+
+            def __call__(self) -> FastAPI:
+                app = FastAPI()
+                auth_router = APIRouter(tags=["authentication"])
+                self._authentication_token_controller.register(auth_router)
+                app.include_router(auth_router)
+                user_router = APIRouter(tags=["user"])
+                self._user_controller.register(user_router)
+                app.include_router(user_router)
+                return app
+        """,
+    )
+    _write_authentication_domain_files(repo_root=repo_root)
+    _write_authentication_test_files(repo_root=repo_root)
+
+
+def _write_authentication_domain_files(*, repo_root: Path) -> None:
+    files = {
+        "apps.py": 'from django.apps import AppConfig\n\n\nclass AuthenticationConfig(AppConfig):\n    name = "fastdjango.core.authentication"\n',
+        "dtos.py": "from fastdjango.foundation.dtos import BaseDTO\n\n\nclass TokenDTO(BaseDTO):\n    access_token: str\n",
+        "exceptions.py": "class AuthenticationError(Exception):\n    pass\n",
+        "models.py": 'from django.db import models\n\n\nclass RefreshSession(models.Model):\n    token = models.CharField(verbose_name="token", max_length=255)\n',
+        "use_cases.py": "from fastdjango.foundation.use_cases import BaseUseCase\n\n\nclass AuthenticationUseCase(BaseUseCase):\n    pass\n",
+        "delivery/django/admin.py": "from django.contrib import admin\n\nfrom fastdjango.core.authentication.models import RefreshSession\n\nadmin.site.register(RefreshSession)\n",
+        "delivery/fastapi/auth.py": "from fastdjango.core.authentication.services.jwt import JWTService\n\n\nclass JWTAuthFactory:\n    pass\n",
+        "delivery/fastapi/controllers.py": "class AuthenticationTokenController:\n    pass\n",
+        "delivery/fastapi/schemas.py": "class TokenRequestSchema:\n    pass\n",
+        "delivery/fastapi/throttling.py": "class UserThrottlerFactory:\n    pass\n",
+        "migrations/__init__.py": "",
+        "migrations/0001_initial.py": "# refresh session migration\n",
+        "services/__init__.py": "",
+        "services/jwt.py": "class JWTService:\n    pass\n",
+        "services/refresh_session.py": "class RefreshSessionService:\n    pass\n",
+    }
+    for relative_path, content in files.items():
+        _write(
+            repo_root / "src" / "fastdjango" / "core" / "authentication" / relative_path,
+            content,
+        )
+
+
+def _write_authentication_test_files(*, repo_root: Path) -> None:
+    _write(
+        repo_root / "tests" / "integration" / "conftest.py",
+        """
+        import pytest
+
+
+        @pytest.fixture(scope="function")
+        def container(monkeypatch: pytest.MonkeyPatch) -> object:
+            monkeypatch.setenv("AUTHENTICATION_MODE", "jwt-refresh-session")
+            monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+            return object()
+        """,
+    )
+    _write(
+        repo_root / "tests" / "integration" / "factories.py",
+        """
+        from fastdjango.core.authentication.services.jwt import JWTService
+
+
+        class TestClientFactory:
+            def __call__(self, *, auth_for_user: object | None = None) -> object:
+                return JWTService()
+        """,
+    )
+    _write(
+        repo_root
+        / "tests"
+        / "integration"
+        / "core"
+        / "authentication"
+        / "delivery"
+        / "fastapi"
+        / "test_controllers.py",
+        "def test_token_controller() -> None:\n    assert True\n",
+    )
+    _write(
+        repo_root
+        / "tests"
+        / "integration"
+        / "core"
+        / "user"
+        / "delivery"
+        / "fastapi"
+        / "test_controllers.py",
+        """
+        def test_get_current_user(test_client_factory: object, user: object) -> None:
+            test_client_factory(auth_for_user=user)
+            assert "/v1/users/me"
+        """,
+    )
+    _write(
+        repo_root / "tests" / "unit" / "core" / "authentication" / "services" / "test_jwt.py",
+        "def test_jwt_service() -> None:\n    assert True\n",
+    )
+    _write(
+        repo_root
+        / "tests"
+        / "unit"
+        / "core"
+        / "authentication"
+        / "services"
+        / "test_refresh_session.py",
+        "def test_refresh_session_service() -> None:\n    assert True\n",
+    )
+    _write(
+        repo_root / "tests" / "unit" / "core" / "authentication" / "test_use_cases.py",
+        "def test_authentication_use_case() -> None:\n    assert True\n",
+    )
 
 
 def _pyproject_content() -> str:
@@ -574,6 +923,11 @@ def _assert_markers_in_order(*, content: str, markers: tuple[str, ...]) -> None:
         marker_position = content.find(marker)
         assert marker_position > previous_position
         previous_position = marker_position
+
+
+def _assert_python_files_parse(*, root: Path) -> None:
+    for path in root.rglob("*.py"):
+        ast.parse(path.read_text(encoding="utf-8"), filename=path.as_posix())
 
 
 def _env_values(*, content: str) -> dict[str, str]:

--- a/tests/setup_wizard/test_prompts.py
+++ b/tests/setup_wizard/test_prompts.py
@@ -1,10 +1,13 @@
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
+import questionary
 from management.setup_wizard import prompts
-from management.setup_wizard.models import DatabaseMode, RedisMode, StorageMode
+from management.setup_wizard.models import AuthenticationMode, DatabaseMode, RedisMode, StorageMode
 from management.setup_wizard.prompts import (
+    _ask_authentication_mode,
     _ask_database_answers,
     _ask_docs_site_url,
     _ask_git_answers,
@@ -167,6 +170,36 @@ def test_minio_ports_are_asked_with_storage_details(monkeypatch: pytest.MonkeyPa
     assert calls == [
         ("MinIO API host port", 9000),
         ("MinIO console host port", 9001),
+    ]
+
+
+def test_authentication_mode_prompt_offers_static_api_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_choices: list[Any] = []
+
+    class FakePrompt:
+        def ask(self) -> AuthenticationMode:
+            return AuthenticationMode.STATIC_API_KEYS
+
+    def fake_select(
+        message: str,
+        *,
+        choices: list[Any],
+        default: AuthenticationMode,
+    ) -> FakePrompt:
+        assert message == "Authentication / authorization"
+        assert default == AuthenticationMode.JWT_REFRESH_SESSION
+        captured_choices.extend(choices)
+        return FakePrompt()
+
+    monkeypatch.setattr(questionary, "select", fake_select)
+
+    assert _ask_authentication_mode() == AuthenticationMode.STATIC_API_KEYS
+    assert [choice.value for choice in captured_choices] == [
+        AuthenticationMode.JWT_REFRESH_SESSION,
+        AuthenticationMode.STATIC_API_KEYS,
+        AuthenticationMode.CUSTOM,
     ]
 
 

--- a/tests/unit/core/authentication/delivery/fastapi/test_auth.py
+++ b/tests/unit/core/authentication/delivery/fastapi/test_auth.py
@@ -1,0 +1,110 @@
+from http import HTTPStatus
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+from starlette.types import Scope
+
+from fastdjango.core.authentication.delivery.fastapi.auth import (
+    StaticAPIKeyAuth,
+    StaticAPIKeyPrincipal,
+    StaticAPIKeyRegistrySettings,
+)
+
+
+def test_static_api_key_registry_parses_json_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "STATIC_API_KEYS",
+        (
+            '{"env-key":{"id":7,"username":"service","email":"service@example.com",'
+            '"is_staff":true,"is_superuser":false}}'
+        ),
+    )
+
+    settings = StaticAPIKeyRegistrySettings()
+
+    principal = settings.get_principal_for_api_key(api_key="env-key")
+    assert principal is not None
+    assert principal.pk == 7
+    assert principal.username == "service"
+    assert principal.is_staff is True
+
+
+@pytest.mark.anyio
+async def test_static_api_key_auth_sets_request_user() -> None:
+    settings = _settings(is_staff=True)
+    request = _request(headers={"X-API-Key": "valid-key"})
+    auth = StaticAPIKeyAuth(settings=settings)
+
+    api_key = await auth(request)
+
+    assert api_key == "valid-key"
+    assert request.state.user.username == "service"
+    assert request.state.user.pk == 1
+
+
+@pytest.mark.anyio
+async def test_static_api_key_auth_rejects_missing_key() -> None:
+    auth = StaticAPIKeyAuth(settings=_settings())
+
+    with pytest.raises(HTTPException) as error:
+        await auth(_request())
+
+    assert error.value.status_code == HTTPStatus.UNAUTHORIZED
+    assert error.value.detail == "API key is required"
+
+
+@pytest.mark.anyio
+async def test_static_api_key_auth_rejects_invalid_key() -> None:
+    auth = StaticAPIKeyAuth(settings=_settings())
+
+    with pytest.raises(HTTPException) as error:
+        await auth(_request(headers={"X-API-Key": "invalid-key"}))
+
+    assert error.value.status_code == HTTPStatus.UNAUTHORIZED
+    assert error.value.detail == "Invalid API key"
+
+
+@pytest.mark.anyio
+async def test_static_api_key_auth_checks_staff_permission() -> None:
+    auth = StaticAPIKeyAuth(settings=_settings(is_staff=False), require_staff=True)
+
+    with pytest.raises(HTTPException) as error:
+        await auth(_request(headers={"X-API-Key": "valid-key"}))
+
+    assert error.value.status_code == HTTPStatus.FORBIDDEN
+    assert error.value.detail == "Staff access required"
+
+
+def _settings(*, is_staff: bool = False) -> StaticAPIKeyRegistrySettings:
+    return StaticAPIKeyRegistrySettings(
+        api_keys={
+            "valid-key": StaticAPIKeyPrincipal(
+                id=1,
+                username="service",
+                email="service@example.com",
+                is_staff=is_staff,
+                is_superuser=False,
+            ),
+        },
+    )
+
+
+def _request(*, headers: dict[str, str] | None = None) -> Request:
+    header_items = [
+        (key.lower().encode(), value.encode()) for key, value in (headers or {}).items()
+    ]
+    scope: Scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": header_items,
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "scheme": "http",
+    }
+    return Request(scope)


### PR DESCRIPTION
## Summary
- Adds setup wizard choices for JWT refresh sessions, static API keys, or custom authentication.
- Generates matching environment values and documentation for the selected authentication path.
- Prunes unused built-in authentication files and tests from generated projects when static or custom authentication is selected.

## Validation
- make format
- make lint
- make test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication mode selection during project setup with three options: JWT refresh sessions, static API keys, and custom authentication.
  * Implemented static API key authentication support.
  * Updated setup wizard to configure authentication based on selected mode.

* **Documentation**
  * Enhanced getting started guides and environment variable reference with authentication configuration details.

* **Chores**
  * Updated environment example files with authentication mode settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->